### PR TITLE
Switch project to claims based authozrization

### DIFF
--- a/src/Kirel.Identity.Blazor.GUI/Kirel.Identity.Blazor.GUI.csproj
+++ b/src/Kirel.Identity.Blazor.GUI/Kirel.Identity.Blazor.GUI.csproj
@@ -12,7 +12,6 @@
 		<PackageReference Include="Blazored.LocalStorage" Version="4.3.0" />
 		<PackageReference Include="CurrieTechnologies.Razor.Clipboard" Version="1.6.0" />
 		<PackageReference Include="Kirel.Blazor.Shared" Version="0.0.4" />
-		<PackageReference Include="Kirel.DTO" Version="0.0.1" />
 		<PackageReference Include="Microsoft.AspNetCore.Authentication.Abstractions" Version="2.2.0" />
 		<PackageReference Include="Microsoft.AspNetCore.Components.Authorization" Version="6.0.13" />
 		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="6.0.13" />

--- a/src/Kirel.Identity.Blazor.GUI/Pages/Roles/RolesList.razor
+++ b/src/Kirel.Identity.Blazor.GUI/Pages/Roles/RolesList.razor
@@ -1,7 +1,7 @@
 ﻿@page "/roles"
 @using CurrieTechnologies.Razor.Clipboard
 @using Kirel.Blazor.Shared
-@using Kirel.DTO
+@using Kirel.Identity.DTOs
 @inject IHttpClientFactory HttpClientFactory
 @inject IDialogService DialogService
 @inject ClipboardService Clipboard
@@ -40,7 +40,7 @@
             <MudIconButton Size="Size.Small" Icon="@Icons.Material.Outlined.ContentCopy" Color="Color.Info"
                            @onclick="async _ => await Clipboard.WriteTextAsync(context.Id.ToString())">
             </MudIconButton>
-            @context.Id
+            @context.Id.ToString()
         </MudTd>
         <MudTd DataLabel="Name">@context.Name</MudTd>
         <MudTd Style="white-space: nowrap; width: 1%;" DataLabel="Options">
@@ -81,10 +81,10 @@
         var request = new HttpRequestMessage(HttpMethod.Get, $"{_relativeUrl}?{uriParamsStr}");
         var response = await _httpClient.SendAsync(request);
         if (!response.IsSuccessStatusCode) return new TableData<RoleDto>();
-        var paginatedList = await response.Content.ReadFromJsonAsync<PaginatedResult<List<RoleDto>>>();
+        var paginatedList = await response.Content.ReadFromJsonAsync<PaginatedItemsDto<RoleDto>>();
         if (paginatedList != null)
         {
-            return new TableData<RoleDto> { TotalItems = paginatedList.Pagination.TotalCount, Items = paginatedList.Data };
+            return new TableData<RoleDto> { TotalItems = paginatedList.Pagination.TotalCount, Items = paginatedList.Items };
         }
         return new TableData<RoleDto>();
     }

--- a/src/Kirel.Identity.Blazor.GUI/Pages/Users/UsersList.razor
+++ b/src/Kirel.Identity.Blazor.GUI/Pages/Users/UsersList.razor
@@ -1,8 +1,8 @@
 ﻿@page "/users"
 @using CurrieTechnologies.Razor.Clipboard
 @using Kirel.Blazor.Shared
-@using Kirel.DTO
 @using System.Globalization
+@using Kirel.Identity.DTOs
 @inject IHttpClientFactory HttpClientFactory
 @inject IDialogService DialogService
 @inject ClipboardService Clipboard
@@ -128,10 +128,10 @@
         var request = new HttpRequestMessage(HttpMethod.Get, $"{_relativeUrl}?{uriParamsStr}");
         var response = await _httpClient.SendAsync(request);
         if (!response.IsSuccessStatusCode) return new TableData<UserDto>();
-        var paginatedList = await response.Content.ReadFromJsonAsync<PaginatedResult<List<UserDto>>>();
+        var paginatedList = await response.Content.ReadFromJsonAsync<PaginatedItemsDto<UserDto>>();
         if (paginatedList != null)
         {
-            return new TableData<UserDto> { TotalItems = paginatedList.Pagination.TotalCount, Items = paginatedList.Data };
+            return new TableData<UserDto> { TotalItems = paginatedList.Pagination.TotalCount, Items = paginatedList.Items };
         }
         return new TableData<UserDto>();
     }

--- a/src/Kirel.Identity.Client.Blazor.Pages/Users/UserEntityDialog.razor.cs
+++ b/src/Kirel.Identity.Client.Blazor.Pages/Users/UserEntityDialog.razor.cs
@@ -192,10 +192,10 @@ public partial class UserEntityDialog<TClaimCreateDto, TClaimUpdateDto, TClaimDt
     private async Task<IEnumerable<TRoleDto>> SearchRoles(string value, CancellationToken token)
     {
         var search = !string.IsNullOrEmpty(value) ? $"search={value}" : string.Empty;
-        var paginatedListDto = await _rolesHttpClient.GetFromJsonAsync<PaginatedResult<List<TRoleDto>>>(
+        var paginatedListDto = await _rolesHttpClient.GetFromJsonAsync<PaginatedItemsDto<TRoleDto>>(
             $"{RolesHttpRelativeUrl}/{search}", token);
 
-        return paginatedListDto is { Data: not null } ? paginatedListDto.Data : new List<TRoleDto>();
+        return paginatedListDto is { Items: not null } ? paginatedListDto.Items : new List<TRoleDto>();
     }
 
     private void AddRole()

--- a/src/Kirel.Identity.Controllers/Extensions/ClaimBasedAuthorizationExtension.cs
+++ b/src/Kirel.Identity.Controllers/Extensions/ClaimBasedAuthorizationExtension.cs
@@ -1,0 +1,44 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+
+namespace Kirel.Identity.Controllers.Extensions;
+
+/// <summary>
+/// Extension methods for setting up claim based authorization in an <see cref="IServiceCollection" />.
+/// </summary>
+public static class ClaimBasedAuthorizationExtension
+{
+    /// <summary>
+    /// Adds authorization services to the specified <see cref="IServiceCollection" />. 
+    /// </summary>
+    /// <param name="services">The <see cref="IServiceCollection" /> to add services to.</param>
+    /// <returns>The <see cref="IServiceCollection"/> so that additional calls can be chained.</returns>
+    public static void AddClaimBasedAuthorization(this IServiceCollection services)
+    {
+        services.AddAuthorization(opts => {
+            opts.AddPolicy(
+            "user_create", b => b.RequireClaim("user", "create")
+            );
+            opts.AddPolicy(
+            "user_read",b =>  b.RequireClaim("user", "read")
+            );
+            opts.AddPolicy(
+            "user_update",b =>  b.RequireClaim("user", "update")
+            );
+            opts.AddPolicy(
+            "user_delete",b =>  b.RequireClaim("user", "delete")
+            );
+            opts.AddPolicy(
+            "role_create", b => b.RequireClaim("role_claim", "create")
+            );
+            opts.AddPolicy(
+            "role_read",b =>  b.RequireClaim("role_claim", "read")
+            );
+            opts.AddPolicy(
+            "role_update",b =>  b.RequireClaim("role_claim", "update")
+            );
+            opts.AddPolicy(
+            "role_delete",b =>  b.RequireClaim("role_claim", "delete")
+            );
+        });
+    }
+}

--- a/src/Kirel.Identity.Controllers/Kirel.Identity.Controllers.csproj
+++ b/src/Kirel.Identity.Controllers/Kirel.Identity.Controllers.csproj
@@ -10,11 +10,10 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.2.0" />
-	</ItemGroup>
-
-	<ItemGroup>
 		<ProjectReference Include="..\Kirel.Identity.Core\Kirel.Identity.Core.csproj" />
+	</ItemGroup>
+	<ItemGroup>
+		<FrameworkReference Include="Microsoft.AspNetCore.App" />
 	</ItemGroup>
 
 </Project>

--- a/src/Kirel.Identity.Controllers/KirelAuthorizedUserController.cs
+++ b/src/Kirel.Identity.Controllers/KirelAuthorizedUserController.cs
@@ -4,6 +4,7 @@ using Kirel.Identity.Core.Models;
 using Kirel.Identity.Core.Services;
 using Kirel.Identity.DTOs;
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 
 namespace Kirel.Identity.Controllers;
@@ -21,13 +22,17 @@ namespace Kirel.Identity.Controllers;
 /// <typeparam name="TAuthorizedUserUpdateDto"> Authorized user update dto </typeparam>
 /// <typeparam name="TRole"> The role entity type </typeparam>
 /// <typeparam name="TUserRole"> The user role entity type </typeparam>
-public class KirelAuthorizedUserController<TAuthorizedUserService, TKey, TUser, TRole, TUserRole, TAuthorizedUserDto,
+/// <typeparam name="TUserClaim"> User claim type. </typeparam>
+/// <typeparam name="TRoleClaim"> Role claim type. </typeparam>
+public class KirelAuthorizedUserController<TAuthorizedUserService, TKey, TUser, TRole, TUserRole, TUserClaim, TRoleClaim, TAuthorizedUserDto,
     TAuthorizedUserUpdateDto> : Controller
-    where TAuthorizedUserService : KirelAuthorizedUserService<TKey, TUser, TRole, TUserRole, TAuthorizedUserDto, TAuthorizedUserUpdateDto>
+    where TAuthorizedUserService : KirelAuthorizedUserService<TKey, TUser, TRole, TUserRole, TUserClaim, TRoleClaim, TAuthorizedUserDto, TAuthorizedUserUpdateDto>
     where TKey : IComparable, IComparable<TKey>, IEquatable<TKey>
-    where TUser : KirelIdentityUser<TKey, TUser, TRole, TUserRole>
-    where TRole : KirelIdentityRole<TKey, TRole, TUser, TUserRole>
-    where TUserRole : KirelIdentityUserRole<TKey, TUserRole, TUser, TRole>
+    where TUser : KirelIdentityUser<TKey, TUser, TRole, TUserRole, TUserClaim, TRoleClaim>
+    where TRole : KirelIdentityRole<TKey, TRole, TUser, TUserRole, TRoleClaim, TUserClaim>
+    where TUserRole : KirelIdentityUserRole<TKey, TUserRole, TUser, TRole, TUserClaim, TRoleClaim>
+    where TRoleClaim : KirelIdentityRoleClaim<TKey>
+    where TUserClaim : KirelIdentityUserClaim<TKey>
     where TAuthorizedUserDto : KirelAuthorizedUserDto
     where TAuthorizedUserUpdateDto : KirelAuthorizedUserUpdateDto
 {

--- a/src/Kirel.Identity.Controllers/KirelAuthorizedUserController.cs
+++ b/src/Kirel.Identity.Controllers/KirelAuthorizedUserController.cs
@@ -24,6 +24,7 @@ namespace Kirel.Identity.Controllers;
 /// <typeparam name="TUserRole"> The user role entity type </typeparam>
 /// <typeparam name="TUserClaim"> User claim type. </typeparam>
 /// <typeparam name="TRoleClaim"> Role claim type. </typeparam>
+[Authorize(AuthenticationSchemes = "Bearer")]
 public class KirelAuthorizedUserController<TAuthorizedUserService, TKey, TUser, TRole, TUserRole, TUserClaim, TRoleClaim, TAuthorizedUserDto,
     TAuthorizedUserUpdateDto> : Controller
     where TAuthorizedUserService : KirelAuthorizedUserService<TKey, TUser, TRole, TUserRole, TUserClaim, TRoleClaim, TAuthorizedUserDto, TAuthorizedUserUpdateDto>
@@ -62,7 +63,6 @@ public class KirelAuthorizedUserController<TAuthorizedUserService, TKey, TUser, 
     /// </summary>
     /// <returns> Authorized user dto </returns>
     [HttpGet]
-    [Authorize(AuthenticationSchemes = "Bearer")]
     public virtual async Task<ActionResult<TAuthorizedUserDto>> GetInfo()
     {
         var result = await AuthorizedUserService.GetDto();
@@ -75,7 +75,6 @@ public class KirelAuthorizedUserController<TAuthorizedUserService, TKey, TUser, 
     /// <param name="updateDto"> Authorized user update dto </param>
     /// <returns> Authorized user dto </returns>
     [HttpPut]
-    [Authorize(AuthenticationSchemes = "Bearer")]
     public virtual async Task<ActionResult<TAuthorizedUserDto>> Update([FromBody] TAuthorizedUserUpdateDto updateDto)
     {
         var dto = await AuthorizedUserService.Update(updateDto);
@@ -88,7 +87,6 @@ public class KirelAuthorizedUserController<TAuthorizedUserService, TKey, TUser, 
     /// <param name="currentPassword"> Current user password </param>
     /// <param name="newPassword"> New user password </param>
     [HttpPut("password")]
-    [Authorize(AuthenticationSchemes = "Bearer")]
     public virtual async Task<ActionResult> ChangePassword(
         [Required] string currentPassword,
         [Required] string newPassword)

--- a/src/Kirel.Identity.Controllers/KirelRegistrationController.cs
+++ b/src/Kirel.Identity.Controllers/KirelRegistrationController.cs
@@ -14,13 +14,17 @@ namespace Kirel.Identity.Controllers;
 /// <typeparam name="TUser"> The user type </typeparam>
 /// <typeparam name="TRole"> The role entity type </typeparam>
 /// <typeparam name="TUserRole"> The user role entity type </typeparam>
-public class KirelRegistrationController<TRegistrationService, TRegistrationDto, TKey, TUser, TRole, TUserRole> : Controller
-    where TRegistrationService : KirelRegistrationService<TKey, TUser, TRole, TUserRole, TRegistrationDto>
+/// <typeparam name="TUserClaim"> User claim type. </typeparam>
+/// <typeparam name="TRoleClaim"> Role claim type. </typeparam>
+public class KirelRegistrationController<TRegistrationService, TRegistrationDto, TKey, TUser, TRole, TUserRole, TUserClaim, TRoleClaim> : Controller
+    where TRegistrationService : KirelRegistrationService<TKey, TUser, TRole, TUserRole, TUserClaim, TRoleClaim, TRegistrationDto>
     where TRegistrationDto : KirelUserRegistrationDto
     where TKey : IComparable, IComparable<TKey>, IEquatable<TKey>
-    where TUser : KirelIdentityUser<TKey, TUser, TRole, TUserRole>
-    where TRole : KirelIdentityRole<TKey, TRole, TUser, TUserRole>
-    where TUserRole : KirelIdentityUserRole<TKey, TUserRole, TUser, TRole>
+    where TUser : KirelIdentityUser<TKey, TUser, TRole, TUserRole, TUserClaim, TRoleClaim>
+    where TRole : KirelIdentityRole<TKey, TRole, TUser, TUserRole, TRoleClaim, TUserClaim>
+    where TUserRole : KirelIdentityUserRole<TKey, TUserRole, TUser, TRole, TUserClaim, TRoleClaim>
+    where TRoleClaim : KirelIdentityRoleClaim<TKey>
+    where TUserClaim : KirelIdentityUserClaim<TKey>
 {
     /// <summary>
     /// Authorized user service

--- a/src/Kirel.Identity.Controllers/KirelRolesController.cs
+++ b/src/Kirel.Identity.Controllers/KirelRolesController.cs
@@ -1,5 +1,4 @@
-﻿using Kirel.DTO;
-using Kirel.Identity.Core.Models;
+﻿using Kirel.Identity.Core.Models;
 using Kirel.Identity.Core.Services;
 using Kirel.Identity.DTOs;
 using Microsoft.AspNetCore.Authorization;
@@ -105,11 +104,11 @@ public class KirelRolesController<TRoleService, TKey, TRole, TUser, TUserRole, T
     /// <returns> Paginated result with list of roles dto </returns>
     [HttpGet]
     [Authorize(Policy = "role_read", AuthenticationSchemes = "Bearer, APIKey")]
-    public virtual async Task<PaginatedResult<List<TRoleDto>>> GetList([FromQuery] int pageNumber = 0, int pageSize = 0,
+    public virtual async Task<PaginatedItemsDto<TRoleDto>> GetList([FromQuery] int pageNumber = 0, int pageSize = 0,
         string orderBy = "", string orderDirection = "asc", string search = "")
     {
-        var directionEnum = SortDirection.Asc;
-        if (orderDirection == "desc") directionEnum = SortDirection.Desc;
+        var directionEnum = SortDirectionDto.Asc;
+        if (orderDirection == "desc") directionEnum = SortDirectionDto.Desc;
         return await Service.GetRolesList(pageNumber, pageSize, search, orderBy, directionEnum);
     }
 }

--- a/src/Kirel.Identity.Controllers/KirelRolesController.cs
+++ b/src/Kirel.Identity.Controllers/KirelRolesController.cs
@@ -21,14 +21,18 @@ namespace Kirel.Identity.Controllers;
 /// <typeparam name="TClaimUpdateDto"> Claim update dto type. Must be a descendant of the KirelClaimUpdateDto class </typeparam>
 /// <typeparam name="TUser"> The user entity type </typeparam>
 /// <typeparam name="TUserRole"> The user entity type </typeparam>
-public class KirelRolesController<TRoleService, TKey, TRole, TUser, TUserRole, TRoleDto, TRoleCreateDto, TRoleUpdateDto, TClaimDto,
+/// <typeparam name="TUserClaim"> User claim type. </typeparam>
+/// <typeparam name="TRoleClaim"> Role claim type. </typeparam>
+public class KirelRolesController<TRoleService, TKey, TRole, TUser, TUserRole, TRoleClaim, TUserClaim, TRoleDto, TRoleCreateDto, TRoleUpdateDto, TClaimDto,
     TClaimCreateDto, TClaimUpdateDto> : Controller
-    where TRoleService : KirelRoleService<TKey, TRole, TUser, TUserRole, TRoleDto, TRoleCreateDto, TRoleUpdateDto, TClaimDto,
+    where TRoleService : KirelRoleService<TKey, TRole, TUser, TUserRole, TRoleClaim, TUserClaim, TRoleDto, TRoleCreateDto, TRoleUpdateDto, TClaimDto,
         TClaimCreateDto, TClaimUpdateDto>
     where TKey : IComparable, IComparable<TKey>, IEquatable<TKey>
-    where TUser : KirelIdentityUser<TKey, TUser, TRole, TUserRole>
-    where TRole : KirelIdentityRole<TKey, TRole, TUser, TUserRole>
-    where TUserRole : KirelIdentityUserRole<TKey, TUserRole, TUser, TRole>
+    where TUser : KirelIdentityUser<TKey, TUser, TRole, TUserRole, TUserClaim, TRoleClaim>
+    where TRole : KirelIdentityRole<TKey, TRole, TUser, TUserRole, TRoleClaim, TUserClaim>
+    where TUserRole : KirelIdentityUserRole<TKey, TUserRole, TUser, TRole, TUserClaim, TRoleClaim>
+    where TRoleClaim : KirelIdentityRoleClaim<TKey>
+    where TUserClaim : KirelIdentityUserClaim<TKey>
     where TRoleDto : KirelRoleDto<TKey, TClaimDto>
     where TRoleCreateDto : KirelRoleCreateDto<TClaimCreateDto>
     where TRoleUpdateDto : KirelRoleUpdateDto<TClaimUpdateDto>

--- a/src/Kirel.Identity.Controllers/KirelRolesController.cs
+++ b/src/Kirel.Identity.Controllers/KirelRolesController.cs
@@ -60,7 +60,7 @@ public class KirelRolesController<TRoleService, TKey, TRole, TUser, TUserRole, T
     /// <param name="createDto"> Role create dto </param>
     /// <returns> Role dto </returns>
     [HttpPost]
-    [Authorize(Roles = "Admin, Microservice", AuthenticationSchemes = "Bearer, APIKey")]
+    [Authorize(Policy = "role_create", AuthenticationSchemes = "Bearer, APIKey")]
     public virtual async Task<ActionResult<TRoleDto>> Create([FromBody] TRoleCreateDto createDto)
     {
         var role = await Service.CreateRole(createDto);
@@ -74,7 +74,7 @@ public class KirelRolesController<TRoleService, TKey, TRole, TUser, TUserRole, T
     /// <param name="id"> Role id </param>
     /// <returns> Role dto </returns>
     [HttpPut("{id}")]
-    [Authorize(Roles = "Admin, Microservice", AuthenticationSchemes = "Bearer, APIKey")]
+    [Authorize(Policy = "role_update", AuthenticationSchemes = "Bearer, APIKey")]
     public virtual async Task<ActionResult<TRoleDto>> Update([FromBody] TRoleUpdateDto updateDto, TKey id)
     {
         var dto = await Service.UpdateRole(id, updateDto);
@@ -87,7 +87,7 @@ public class KirelRolesController<TRoleService, TKey, TRole, TUser, TUserRole, T
     /// <param name="id"> Role id </param>
     /// <returns> Role dto </returns>
     [HttpGet("{id}")]
-    [Authorize(Roles = "Admin, Microservice", AuthenticationSchemes = "Bearer, APIKey")]
+    [Authorize(Policy = "role_read", AuthenticationSchemes = "Bearer, APIKey")]
     public virtual async Task<ActionResult<TRoleDto>> GetById(TKey id)
     {
         var result = await Service.GetRole(id);
@@ -104,7 +104,7 @@ public class KirelRolesController<TRoleService, TKey, TRole, TUser, TUserRole, T
     /// <param name="search"> Search string parameter </param>
     /// <returns> Paginated result with list of roles dto </returns>
     [HttpGet]
-    [Authorize(Roles = "Admin, Microservice", AuthenticationSchemes = "Bearer, APIKey")]
+    [Authorize(Policy = "role_read", AuthenticationSchemes = "Bearer, APIKey")]
     public virtual async Task<PaginatedResult<List<TRoleDto>>> GetList([FromQuery] int pageNumber = 0, int pageSize = 0,
         string orderBy = "", string orderDirection = "asc", string search = "")
     {

--- a/src/Kirel.Identity.Controllers/KirelUsersController.cs
+++ b/src/Kirel.Identity.Controllers/KirelUsersController.cs
@@ -1,5 +1,4 @@
-﻿using Kirel.DTO;
-using Kirel.Identity.Core.Models;
+﻿using Kirel.Identity.Core.Models;
 using Kirel.Identity.Core.Services;
 using Kirel.Identity.DTOs;
 using Microsoft.AspNetCore.Authorization;
@@ -106,11 +105,11 @@ public class KirelUsersController<TUserService, TKey, TUser, TRole, TUserRole, T
     /// <returns> Paginated result with list of users dto </returns>
     [HttpGet]
     [Authorize(Policy = "user_read", AuthenticationSchemes = "Bearer, APIKey")]
-    public virtual async Task<PaginatedResult<List<TUserDto>>> GetList([FromQuery] int pageNumber = 0, int pageSize = 0,
+    public virtual async Task<PaginatedItemsDto<TUserDto>> GetList([FromQuery] int pageNumber = 0, int pageSize = 0,
         string orderBy = "", string orderDirection = "asc", string search = "", [FromQuery] IEnumerable<TKey>? roleIds = null)
     {
-        var directionEnum = SortDirection.Asc;
-        if (orderDirection == "desc") directionEnum = SortDirection.Desc;
+        var directionEnum = SortDirectionDto.Asc;
+        if (orderDirection == "desc") directionEnum = SortDirectionDto.Desc;
         return await Service.GetUsersList(pageNumber, pageSize, search, orderBy, directionEnum, roleIds);
     }
 }

--- a/src/Kirel.Identity.Controllers/KirelUsersController.cs
+++ b/src/Kirel.Identity.Controllers/KirelUsersController.cs
@@ -60,7 +60,7 @@ public class KirelUsersController<TUserService, TKey, TUser, TRole, TUserRole, T
     /// <param name="createDto"> User create dto </param>
     /// <returns> User dto </returns>
     [HttpPost]
-    [Authorize(Roles = "Admin, Microservice", AuthenticationSchemes = "Bearer, APIKey")]
+    [Authorize(Policy = "user_create", AuthenticationSchemes = "Bearer, APIKey")]
     public virtual async Task<ActionResult<TUserDto>> Create([FromBody] TUserCreateDto createDto)
     {
         var dto = await Service.CreateUser(createDto);
@@ -74,7 +74,7 @@ public class KirelUsersController<TUserService, TKey, TUser, TRole, TUserRole, T
     /// <param name="id"> User id </param>
     /// <returns> User dto </returns>
     [HttpPut("{id}")]
-    [Authorize(Roles = "Admin, Microservice", AuthenticationSchemes = "Bearer, APIKey")]
+    [Authorize(Policy = "user_update", AuthenticationSchemes = "Bearer, APIKey")]
     public virtual async Task<ActionResult<TUserDto>> Update([FromBody] TUserUpdateDto updateDto, TKey id)
     {
         var dto = await Service.UpdateUser(id, updateDto);
@@ -87,7 +87,7 @@ public class KirelUsersController<TUserService, TKey, TUser, TRole, TUserRole, T
     /// <param name="id"> User id </param>
     /// <returns> User dto </returns>
     [HttpGet("{id}")]
-    [Authorize(Roles = "Admin, Microservice", AuthenticationSchemes = "Bearer, APIKey")]
+    [Authorize(Policy = "user_read", AuthenticationSchemes = "Bearer, APIKey")]
     public virtual async Task<ActionResult<TUserDto>> GetById(TKey id)
     {
         var result = await Service.GetById(id);
@@ -105,7 +105,7 @@ public class KirelUsersController<TUserService, TKey, TUser, TRole, TUserRole, T
     /// <param name="roleIds"></param>
     /// <returns> Paginated result with list of users dto </returns>
     [HttpGet]
-    [Authorize(Roles = "Admin, Microservice", AuthenticationSchemes = "Bearer, APIKey")]
+    [Authorize(Policy = "user_read", AuthenticationSchemes = "Bearer, APIKey")]
     public virtual async Task<PaginatedResult<List<TUserDto>>> GetList([FromQuery] int pageNumber = 0, int pageSize = 0,
         string orderBy = "", string orderDirection = "asc", string search = "", [FromQuery] IEnumerable<TKey>? roleIds = null)
     {

--- a/src/Kirel.Identity.Controllers/KirelUsersController.cs
+++ b/src/Kirel.Identity.Controllers/KirelUsersController.cs
@@ -21,14 +21,18 @@ namespace Kirel.Identity.Controllers;
 /// <typeparam name="TClaimCreateDto"> Claim create dto type. Must be a descendant of the KirelClaimCreateDto class </typeparam>
 /// <typeparam name="TClaimUpdateDto"> Claim update dto type. Must be a descendant of the KirelClaimUpdateDto class </typeparam>
 /// <typeparam name="TUserRole"> The user role entity type </typeparam>
-public class KirelUsersController<TUserService, TKey, TUser, TRole, TUserRole, TUserDto, TUserCreateDto, TUserUpdateDto, TClaimDto,
+/// <typeparam name="TUserClaim"> User claim type. </typeparam>
+/// <typeparam name="TRoleClaim"> Role claim type. </typeparam>
+public class KirelUsersController<TUserService, TKey, TUser, TRole, TUserRole, TUserClaim, TRoleClaim, TUserDto, TUserCreateDto, TUserUpdateDto, TClaimDto,
     TClaimCreateDto, TClaimUpdateDto> : Controller
-    where TUserService : KirelUserService<TKey, TUser, TRole, TUserRole, TUserDto, TUserCreateDto, TUserUpdateDto, TClaimDto,
+    where TUserService : KirelUserService<TKey, TUser, TRole, TUserRole, TUserClaim, TRoleClaim, TUserDto, TUserCreateDto, TUserUpdateDto, TClaimDto,
         TClaimCreateDto, TClaimUpdateDto>
     where TKey : IComparable, IComparable<TKey>, IEquatable<TKey>
-    where TUser : KirelIdentityUser<TKey, TUser, TRole, TUserRole>
-    where TRole : KirelIdentityRole<TKey, TRole, TUser, TUserRole>
-    where TUserRole : KirelIdentityUserRole<TKey, TUserRole, TUser, TRole>
+    where TUser : KirelIdentityUser<TKey, TUser, TRole, TUserRole, TUserClaim, TRoleClaim>
+    where TRole : KirelIdentityRole<TKey, TRole, TUser, TUserRole, TRoleClaim, TUserClaim>
+    where TUserRole : KirelIdentityUserRole<TKey, TUserRole, TUser, TRole, TUserClaim, TRoleClaim>
+    where TRoleClaim : KirelIdentityRoleClaim<TKey>
+    where TUserClaim : KirelIdentityUserClaim<TKey>
     where TUserDto : KirelUserDto<TKey, TKey, TClaimDto>
     where TUserCreateDto : KirelUserCreateDto<TKey, TClaimCreateDto>
     where TUserUpdateDto : KirelUserUpdateDto<TKey, TClaimUpdateDto>

--- a/src/Kirel.Identity.Core/Kirel.Identity.Core.csproj
+++ b/src/Kirel.Identity.Core/Kirel.Identity.Core.csproj
@@ -13,7 +13,6 @@
 		<PackageReference Include="AutoMapper" Version="12.0.0" />
 		<PackageReference Include="FluentValidation" Version="11.4.0" />
 		<PackageReference Include="Kirel.DTO" Version="0.0.1" />
-		<PackageReference Include="Kirel.Shared" Version="0.0.2" />
 		<PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
 		<PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="6.0.12" />
 		<PackageReference Include="Microsoft.IdentityModel.Tokens" Version="6.25.1" />

--- a/src/Kirel.Identity.Core/Kirel.Identity.Core.csproj
+++ b/src/Kirel.Identity.Core/Kirel.Identity.Core.csproj
@@ -12,7 +12,6 @@
 	<ItemGroup>
 		<PackageReference Include="AutoMapper" Version="12.0.0" />
 		<PackageReference Include="FluentValidation" Version="11.4.0" />
-		<PackageReference Include="Kirel.DTO" Version="0.0.1" />
 		<PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
 		<PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="6.0.12" />
 		<PackageReference Include="Microsoft.IdentityModel.Tokens" Version="6.25.1" />

--- a/src/Kirel.Identity.Core/Models/KirelIdentityRole.cs
+++ b/src/Kirel.Identity.Core/Models/KirelIdentityRole.cs
@@ -5,14 +5,20 @@ namespace Kirel.Identity.Core.Models;
 /// <summary>
 /// The default implementation of <see cref="IdentityRole" /> which uses a string as the primary key.
 /// </summary>
-public class KirelIdentityRole<TKey, TRole, TUser, TUserRole> : IdentityRole<TKey> 
+public class KirelIdentityRole<TKey, TRole, TUser, TUserRole, TRoleClaim, TUserClaim> : IdentityRole<TKey> 
 where TKey : IComparable, IComparable<TKey>, IEquatable<TKey>
-where TRole : KirelIdentityRole<TKey, TRole, TUser, TUserRole>
-where TUser : KirelIdentityUser<TKey, TUser, TRole, TUserRole>
-where TUserRole : KirelIdentityUserRole<TKey, TUserRole, TUser, TRole>
+where TRole : KirelIdentityRole<TKey, TRole, TUser, TUserRole, TRoleClaim, TUserClaim>
+where TUser : KirelIdentityUser<TKey, TUser, TRole, TUserRole, TUserClaim, TRoleClaim>
+where TUserRole : KirelIdentityUserRole<TKey, TUserRole, TUser, TRole, TUserClaim, TRoleClaim>
+where TRoleClaim : IdentityRoleClaim<TKey>
+where TUserClaim : IdentityUserClaim<TKey>
 {
     /// <summary>
     /// List of user roles 
     /// </summary>
-    public virtual ICollection<TUserRole> UserRoles { get; set; } = null!;
+    public virtual ICollection<TUserRole> UserRoles { get; } = null!;
+    /// <summary>
+    /// Claims of the role
+    /// </summary>
+    public virtual ICollection<TRoleClaim> Claims { get; } = null!;
 }

--- a/src/Kirel.Identity.Core/Models/KirelIdentityRole.cs
+++ b/src/Kirel.Identity.Core/Models/KirelIdentityRole.cs
@@ -20,5 +20,5 @@ where TUserClaim : IdentityUserClaim<TKey>
     /// <summary>
     /// Claims of the role
     /// </summary>
-    public virtual ICollection<TRoleClaim> Claims { get; } = null!;
+    public virtual ICollection<TRoleClaim> Claims { get; set; } = null!;
 }

--- a/src/Kirel.Identity.Core/Models/KirelIdentityUser.cs
+++ b/src/Kirel.Identity.Core/Models/KirelIdentityUser.cs
@@ -6,11 +6,13 @@ namespace Kirel.Identity.Core.Models;
 /// <summary>
 /// The default implementation of <see cref="IdentityUser{TKey}" />.
 /// </summary>
-public class KirelIdentityUser<TKey, TUser, TRole, TUserRole> : IdentityUser<TKey>, IKirelUser<TKey>
+public class KirelIdentityUser<TKey, TUser, TRole, TUserRole, TUserClaim, TRoleClaim> : IdentityUser<TKey>, IKirelUser<TKey>
     where TKey : IComparable, IComparable<TKey>, IEquatable<TKey>
-    where TUser : KirelIdentityUser<TKey, TUser, TRole, TUserRole>
-    where TRole : KirelIdentityRole<TKey, TRole, TUser, TUserRole>
-    where TUserRole : KirelIdentityUserRole<TKey, TUserRole, TUser, TRole>
+    where TUser : KirelIdentityUser<TKey, TUser, TRole, TUserRole, TUserClaim, TRoleClaim>
+    where TRole : KirelIdentityRole<TKey, TRole, TUser, TUserRole, TRoleClaim, TUserClaim>
+    where TUserRole : KirelIdentityUserRole<TKey, TUserRole, TUser, TRole, TUserClaim, TRoleClaim>
+    where TUserClaim : IdentityUserClaim<TKey>
+    where TRoleClaim : IdentityRoleClaim<TKey>
 {
     /// <summary>
     /// First name of the user
@@ -36,4 +38,8 @@ public class KirelIdentityUser<TKey, TUser, TRole, TUserRole> : IdentityUser<TKe
     /// List of user roles
     /// </summary>
     public virtual ICollection<TUserRole> UserRoles { get; set; } = null!;
+    /// <summary>
+    /// Claims of the user
+    /// </summary>
+    public virtual ICollection<TUserClaim> Claims { get; set; } = null!;
 }

--- a/src/Kirel.Identity.Core/Models/KirelIdentityUserClaim.cs
+++ b/src/Kirel.Identity.Core/Models/KirelIdentityUserClaim.cs
@@ -9,4 +9,5 @@ namespace Kirel.Identity.Core.Models;
 public class KirelIdentityUserClaim<TKey> : IdentityUserClaim<TKey>
     where TKey : IComparable, IComparable<TKey>, IEquatable<TKey>
 {
+    
 }

--- a/src/Kirel.Identity.Core/Models/KirelIdentityUserRole.cs
+++ b/src/Kirel.Identity.Core/Models/KirelIdentityUserRole.cs
@@ -9,11 +9,15 @@ namespace Kirel.Identity.Core.Models;
 /// <typeparam name="TUserRole"> The user role entity type. </typeparam>
 /// <typeparam name="TUser"> The user entity type. </typeparam>
 /// <typeparam name="TRole"> The role entity type. </typeparam>
-public class KirelIdentityUserRole<TKey, TUserRole, TUser, TRole> : IdentityUserRole<TKey>
+/// <typeparam name="TUserClaim"> User claim type. </typeparam>
+/// <typeparam name="TRoleClaim"> Role claim type. </typeparam>
+public class KirelIdentityUserRole<TKey, TUserRole, TUser, TRole, TUserClaim, TRoleClaim> : IdentityUserRole<TKey>
 where TKey : IComparable, IComparable<TKey>, IEquatable<TKey>
-where TUser : KirelIdentityUser<TKey, TUser, TRole, TUserRole>
-where TRole : KirelIdentityRole<TKey, TRole, TUser, TUserRole>
-where TUserRole : KirelIdentityUserRole<TKey, TUserRole, TUser, TRole>
+where TUser : KirelIdentityUser<TKey, TUser, TRole, TUserRole, TUserClaim, TRoleClaim>
+where TRole : KirelIdentityRole<TKey, TRole, TUser, TUserRole, TRoleClaim, TUserClaim>
+where TUserRole : KirelIdentityUserRole<TKey, TUserRole, TUser, TRole, TUserClaim, TRoleClaim>
+where TRoleClaim : IdentityRoleClaim<TKey>
+where TUserClaim : IdentityUserClaim<TKey>
 {
     /// <summary>
     /// Linked user entity

--- a/src/Kirel.Identity.Core/Services/KirelAuthenticationService.cs
+++ b/src/Kirel.Identity.Core/Services/KirelAuthenticationService.cs
@@ -11,11 +11,15 @@ namespace Kirel.Identity.Core.Services;
 /// <typeparam name="TUser"> User entity type. </typeparam>
 /// <typeparam name="TRole"> Role entity type. </typeparam>
 /// <typeparam name="TUserRole"> Role user entity type. </typeparam>
-public class KirelAuthenticationService<TKey, TUser, TRole, TUserRole>
+/// <typeparam name="TUserClaim"> User claim type. </typeparam>
+/// <typeparam name="TRoleClaim"> Role claim type. </typeparam>
+public class KirelAuthenticationService<TKey, TUser, TRole, TUserRole, TUserClaim, TRoleClaim>
     where TKey : IComparable, IComparable<TKey>, IEquatable<TKey>
-    where TUser : KirelIdentityUser<TKey, TUser, TRole, TUserRole>
-    where TRole : KirelIdentityRole<TKey, TRole, TUser, TUserRole>
-    where TUserRole : KirelIdentityUserRole<TKey, TUserRole, TUser, TRole>
+    where TUser : KirelIdentityUser<TKey, TUser, TRole, TUserRole, TUserClaim, TRoleClaim>
+    where TRole : KirelIdentityRole<TKey, TRole, TUser, TUserRole, TRoleClaim, TUserClaim>
+    where TUserRole : KirelIdentityUserRole<TKey, TUserRole, TUser, TRole, TUserClaim, TRoleClaim>
+    where TRoleClaim : KirelIdentityRoleClaim<TKey>
+    where TUserClaim : KirelIdentityUserClaim<TKey>
 {
     /// <summary>
     /// Identity user manager

--- a/src/Kirel.Identity.Core/Services/KirelRegistrationService.cs
+++ b/src/Kirel.Identity.Core/Services/KirelRegistrationService.cs
@@ -14,11 +14,15 @@ namespace Kirel.Identity.Core.Services;
 /// <typeparam name="TRegistrationDto"> User registration dto type </typeparam>
 /// <typeparam name="TRole"> Role entity type. </typeparam>
 /// <typeparam name="TUserRole"> User role entity type. </typeparam>
-public class KirelRegistrationService<TKey, TUser, TRole, TUserRole, TRegistrationDto>
+/// <typeparam name="TUserClaim"> User claim type. </typeparam>
+/// <typeparam name="TRoleClaim"> Role claim type. </typeparam>
+public class KirelRegistrationService<TKey, TUser, TRole, TUserRole, TUserClaim, TRoleClaim, TRegistrationDto>
     where TKey : IComparable, IComparable<TKey>, IEquatable<TKey>
-    where TUser : KirelIdentityUser<TKey, TUser, TRole, TUserRole>
-    where TRole : KirelIdentityRole<TKey, TRole, TUser, TUserRole>
-    where TUserRole : KirelIdentityUserRole<TKey, TUserRole, TUser, TRole>
+    where TUser : KirelIdentityUser<TKey, TUser, TRole, TUserRole, TUserClaim, TRoleClaim>
+    where TRole : KirelIdentityRole<TKey, TRole, TUser, TUserRole, TRoleClaim, TUserClaim>
+    where TUserRole : KirelIdentityUserRole<TKey, TUserRole, TUser, TRole, TUserClaim, TRoleClaim>
+    where TRoleClaim : KirelIdentityRoleClaim<TKey>
+    where TUserClaim : KirelIdentityUserClaim<TKey>
     where TRegistrationDto : KirelUserRegistrationDto
 {
     /// <summary>

--- a/src/Kirel.Identity.Core/Services/KirelRoleService.cs
+++ b/src/Kirel.Identity.Core/Services/KirelRoleService.cs
@@ -1,6 +1,5 @@
 ﻿using System.Linq.Expressions;
 using AutoMapper;
-using Kirel.DTO;
 using Kirel.Identity.Core.Models;
 using Kirel.Identity.DTOs;
 using Kirel.Identity.Exceptions;
@@ -126,8 +125,8 @@ public class KirelRoleService<TKey, TRole, TUser, TUserRole, TRoleClaim, TUserCl
     /// <param name="orderDirection"> Ascending or descending order direction </param>
     /// <returns> List of roles dto with pagination </returns>
     /// <exception cref="ArgumentOutOfRangeException"> If passed wrong sort direction </exception>
-    public virtual async Task<PaginatedResult<List<TRoleDto>>> GetRolesList(int page, int pageSize, string search,
-        string orderBy, SortDirection orderDirection)
+    public virtual async Task<PaginatedItemsDto<TRoleDto>> GetRolesList(int page, int pageSize, string search,
+        string orderBy, SortDirectionDto orderDirection)
     {
         page = page < 1 ? 1 : page;
         pageSize = pageSize < 1 ? 10 : pageSize;
@@ -145,7 +144,7 @@ public class KirelRoleService<TKey, TRole, TUser, TUserRole, TRoleClaim, TUserCl
         
         return await GetRolesList(page, pageSize, finalExpression, orderByFunc);
     }
-    internal virtual async Task<PaginatedResult<List<TRoleDto>>> GetRolesList(int page, int pageSize, 
+    internal virtual async Task<PaginatedItemsDto<TRoleDto>> GetRolesList(int page, int pageSize, 
         Expression<Func<TRole, bool>>? filterBy,
         Func<IQueryable<TRole>, IOrderedQueryable<TRole>>? orderBy)
     {
@@ -157,11 +156,11 @@ public class KirelRoleService<TKey, TRole, TUser, TUserRole, TRoleClaim, TUserCl
         
         appRoles = appRoles.Skip((page - 1) * pageSize).Take(pageSize);
         
-        var pagination = Pagination.Generate(page, pageSize, count);
-        return new PaginatedResult<List<TRoleDto>>
+        var pagination = PaginationDto.Generate(page, pageSize, count);
+        return new PaginatedItemsDto<TRoleDto>
         {
             Pagination = pagination,
-            Data = Mapper.Map<List<TRoleDto>>(appRoles)
+            Items = Mapper.Map<List<TRoleDto>>(appRoles)
         };
     }
 }

--- a/src/Kirel.Identity.Core/Services/KirelRoleService.cs
+++ b/src/Kirel.Identity.Core/Services/KirelRoleService.cs
@@ -1,11 +1,9 @@
 ﻿using System.Linq.Expressions;
-using System.Security.Claims;
 using AutoMapper;
 using Kirel.DTO;
 using Kirel.Identity.Core.Models;
 using Kirel.Identity.DTOs;
 using Kirel.Identity.Exceptions;
-using Kirel.Shared;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
 
@@ -138,7 +136,7 @@ public class KirelRoleService<TKey, TRole, TUser, TUserRole, TRoleClaim, TUserCl
         Func<IQueryable<TRole>, IOrderedQueryable<TRole>>? orderByFunc = null;
 
         if (!string.IsNullOrEmpty(search))
-            searchExpression = PredicateBuilder.PredicateSearchInAllFields<TRole>(search, true);
+            searchExpression = PredicateBuilder.PredicateSearchInAllFields<TRole>(search, false);
         
         if (!string.IsNullOrEmpty(orderBy)) 
             orderByFunc = ServiceHelper.GenerateOrderingMethod<TRole>(orderBy, orderDirection);

--- a/src/Kirel.Identity.Core/Services/KirelUserService.cs
+++ b/src/Kirel.Identity.Core/Services/KirelUserService.cs
@@ -1,5 +1,4 @@
 ﻿using System.Linq.Expressions;
-using System.Security.Claims;
 using AutoMapper;
 using Kirel.DTO;
 using Kirel.Identity.Core.Models;
@@ -23,13 +22,17 @@ namespace Kirel.Identity.Core.Services;
 /// <typeparam name="TClaimDto"> Claim dto. Must be a descendant of the KirelClaimDto class </typeparam>
 /// <typeparam name="TClaimCreateDto"> Claim create dto. Must be a descendant of the KirelClaimCreateDto class </typeparam>
 /// <typeparam name="TClaimUpdateDto"> Claim update dto. Must be a descendant of the KirelClaimUpdateDto class </typeparam>
-/// <typeparam name="TUserRole"> User role entity type </typeparam>
-public class KirelUserService<TKey, TUser, TRole, TUserRole, TUserDto, TUserCreateDto, TUserUpdateDto, TClaimDto, TClaimCreateDto,
+/// <typeparam name="TUserRole"> User role entity type. </typeparam>
+/// <typeparam name="TUserClaim"> User claim type. </typeparam>
+/// <typeparam name="TRoleClaim"> Role claim type. </typeparam>
+public class KirelUserService<TKey, TUser, TRole, TUserRole, TUserClaim, TRoleClaim, TUserDto, TUserCreateDto, TUserUpdateDto, TClaimDto, TClaimCreateDto,
     TClaimUpdateDto>
     where TKey : IComparable, IComparable<TKey>, IEquatable<TKey>
-    where TUser : KirelIdentityUser<TKey, TUser, TRole, TUserRole>
-    where TRole : KirelIdentityRole<TKey, TRole, TUser, TUserRole>
-    where TUserRole : KirelIdentityUserRole<TKey, TUserRole, TUser, TRole>
+    where TUser : KirelIdentityUser<TKey, TUser, TRole, TUserRole, TUserClaim, TRoleClaim>
+    where TRole : KirelIdentityRole<TKey, TRole, TUser, TUserRole, TRoleClaim, TUserClaim>
+    where TUserRole : KirelIdentityUserRole<TKey, TUserRole, TUser, TRole, TUserClaim, TRoleClaim>
+    where TRoleClaim : KirelIdentityRoleClaim<TKey>
+    where TUserClaim : KirelIdentityUserClaim<TKey>
     where TUserDto : KirelUserDto<TKey, TKey, TClaimDto>
     where TUserCreateDto : KirelUserCreateDto<TKey, TClaimCreateDto>
     where TUserUpdateDto : KirelUserUpdateDto<TKey, TClaimUpdateDto>
@@ -43,112 +46,26 @@ public class KirelUserService<TKey, TUser, TRole, TUserRole, TUserDto, TUserCrea
     protected readonly IMapper Mapper;
 
     /// <summary>
-    /// Identity role manager
-    /// </summary>
-    protected readonly RoleManager<TRole> RoleManager;
-
-    /// <summary>
     /// Identity user manager
     /// </summary>
     protected readonly UserManager<TUser> UserManager;
+    /// <summary>
+    /// Users queryable instance
+    /// </summary>
+    protected virtual IQueryable<TUser> Users
+    {
+        get => UserManager.Users;
+    }
 
     /// <summary>
     /// KirelUserService constructor
     /// </summary>
     /// <param name="userManager"> Identity user manager </param>
-    /// <param name="roleManager"> Identity role manager </param>
     /// <param name="mapper"> AutoMapper instance </param>
-    public KirelUserService(UserManager<TUser> userManager, RoleManager<TRole> roleManager, IMapper mapper)
+    public KirelUserService(UserManager<TUser> userManager, IMapper mapper)
     {
         UserManager = userManager;
-        RoleManager = roleManager;
         Mapper = mapper;
-    }
-
-    /// <summary>
-    /// Deletes given claim from the user
-    /// </summary>
-    /// <param name="claim"> Claim to delete </param>
-    /// <param name="userId"> User id </param>
-    /// <exception cref="KirelNotFoundException"> If user or claim was not found </exception>
-    private async Task DeleteClaimFromUser(Claim claim, TKey userId)
-    {
-        var user = await UserManager.FindByIdAsync(userId.ToString());
-        if (user == null)
-            throw new KirelNotFoundException($"User with specified id {userId} was not found");
-
-        var userClaims = await UserManager.GetClaimsAsync(user);
-        if (!userClaims.Any(userClaim => userClaim.Type == claim.Type && userClaim.Value == claim.Value))
-            throw new KirelNotFoundException($"This claim {claim.Type} was not found for the specified user {userId}");
-        await UserManager.RemoveClaimAsync(user, claim);
-    }
-
-    /// <summary>
-    /// Gets list of user claims
-    /// </summary>
-    /// <param name="userId"> User id </param>
-    /// <returns> List of user claims </returns>
-    /// <exception cref="KirelNotFoundException"> If user with given id was not found </exception>
-    private async Task<IList<Claim>> GetUserClaims(TKey userId)
-    {
-        var user = await UserManager.FindByIdAsync(userId.ToString());
-        if (user == null)
-            throw new KirelNotFoundException($"User with specified id {userId} was not found");
-        return await UserManager.GetClaimsAsync(user);
-    }
-
-    private async Task<List<TKey>> GetUserRolesIds(TKey userId)
-    {
-        var user = await UserManager.FindByIdAsync(userId.ToString());
-        if (user == null)
-            throw new KirelNotFoundException($"User with specified id {userId} was not found");
-        var roles = await UserManager.GetRolesAsync(user);
-        return await RoleManager.Roles.Where(r => roles.Contains(r.Name))
-            .Select(r => r.Id).ToListAsync();
-    }
-
-    /// <summary>
-    /// Adds new claim to the user
-    /// </summary>
-    /// <param name="claim"> Claim </param>
-    /// <param name="userId"> User id </param>
-    /// <exception cref="KirelNotFoundException"> If user with given id was not found </exception>
-    private async Task AddClaimToUser(Claim claim, TKey userId)
-    {
-        var user = await UserManager.FindByIdAsync(userId.ToString());
-        if (user == null)
-            throw new KirelNotFoundException($"User with specified id {userId} was not found");
-        await UserManager.AddClaimAsync(user, claim);
-    }
-
-    private async Task SyncUserRoles(TKey userId, List<TKey> roles)
-    {
-        var user = await UserManager.FindByIdAsync(userId.ToString());
-        var userRoles = await UserManager.GetRolesAsync(user);
-        foreach (var roleId in roles)
-        {
-            var role = await RoleManager.FindByIdAsync(roleId.ToString());
-            if (!userRoles.Contains(role.Name)) await AddUserToRole(userId, roleId);
-        }
-
-        foreach (var roleName in userRoles)
-        {
-            var role = await RoleManager.FindByNameAsync(roleName);
-            if (!roles.Contains(role.Id)) await DeleteUserFromRole(userId, role.Id);
-        }
-    }
-
-    private async Task SyncUserClaims(TKey userId, List<TClaimUpdateDto> dtoClaims)
-    {
-        var userClaims = await GetUserClaims(userId);
-        var claimsFromDto = Mapper.Map<List<Claim>>(dtoClaims);
-        foreach (var claim in claimsFromDto)
-            if (!userClaims.Any(userClaim => userClaim.Type == claim.Type && userClaim.Value == claim.Value))
-                await AddClaimToUser(claim, userId);
-        foreach (var claim in userClaims)
-            if (!claimsFromDto.Any(claimFromDto =>
-                    claimFromDto.Type == claim.Type && claimFromDto.Value == claim.Value))
-                await DeleteClaimFromUser(claim, userId);
     }
 
     /// <summary>
@@ -159,13 +76,10 @@ public class KirelUserService<TKey, TUser, TRole, TUserRole, TUserDto, TUserCrea
     /// <exception cref="KirelNotFoundException"> If user with given id was not found </exception>
     public virtual async Task<TUserDto> GetById(TKey userId)
     {
-        var user = await UserManager.FindByIdAsync(userId.ToString());
+        var user = await Users.FirstOrDefaultAsync(u => u.Id.Equals(userId));
         if (user == null)
             throw new KirelNotFoundException($"User with specified id {userId} was not found");
-        var claims = await GetUserClaims(userId);
         var userDto = Mapper.Map<TUserDto>(user);
-        userDto.Claims = Mapper.Map<List<TClaimDto>>(claims);
-        userDto.Roles = await GetUserRolesIds(userId);
         return userDto;
     }
 
@@ -183,8 +97,8 @@ public class KirelUserService<TKey, TUser, TRole, TUserRole, TUserDto, TUserCrea
     public virtual async Task<PaginatedResult<List<TUserDto>>> GetUsersList(int page, int pageSize, string search,
         string orderBy, SortDirection orderDirection, IEnumerable<TKey>? roleIds = null)
     {
-        page = page < 1 ? 0 : page;
-        pageSize = pageSize < 1 ? 0 : pageSize;
+        page = page < 1 ? 1 : page;
+        pageSize = pageSize < 1 ? 10 : pageSize;
         Expression<Func<TUser, bool>>? searchExpression = _ => true;
         Expression<Func<TUser, bool>>? rolesIdsExpression = _ => true;
         Func<IQueryable<TUser>, IOrderedQueryable<TUser>>? orderByFunc = null;
@@ -215,34 +129,23 @@ public class KirelUserService<TKey, TUser, TRole, TUserRole, TUserDto, TUserCrea
         Expression<Func<TUser, bool>>? filterBy,
         Func<IQueryable<TUser>, IOrderedQueryable<TUser>>? orderBy)
     {
-        page = page < 1 ? 0 : page;
-        pageSize = pageSize < 1 ? 0 : pageSize;
-
-        var appUsers = UserManager.Users;
+        var appUsers = Users;
         appUsers = orderBy == null ? appUsers.OrderByDescending(u => u.Created) : orderBy(appUsers);
-            
         
         if (filterBy != null) appUsers = appUsers.Where(filterBy);
         var count = await appUsers.CountAsync();
-        if (page > 0 && pageSize > 0)
-            appUsers = appUsers.Skip((page - 1) * pageSize).Take(pageSize);
+        
+        appUsers = appUsers.Skip((page - 1) * pageSize).Take(pageSize);
         
         var pagination = Pagination.Generate(page, pageSize, count);
         var data = Mapper.Map<List<TUserDto>>(appUsers);
-        foreach (var userDto in data)
-        {
-            var userClaims = await GetUserClaims(userDto.Id);
-            userDto.Claims = Mapper.Map<List<TClaimDto>>(userClaims);
-            userDto.Roles = await GetUserRolesIds(userDto.Id);
-        }
-
         return new PaginatedResult<List<TUserDto>>
         {
             Pagination = pagination,
             Data = data
         };
     }
-
+    
     /// <summary>
     /// Creates new user
     /// </summary>
@@ -253,28 +156,14 @@ public class KirelUserService<TKey, TUser, TRole, TUserRole, TUserDto, TUserCrea
     public virtual async Task<TUserDto> CreateUser(TUserCreateDto createDto)
     {
         var appUser = Mapper.Map<TUser>(createDto);
-        var result = await UserManager.CreateAsync(appUser);
+        await UserManager.CreateAsync(appUser);
+        var result = await UserManager.AddPasswordAsync(appUser, createDto.Password);
         if (!result.Succeeded)
-            throw new KirelIdentityStoreException("Failed to create new user");
-        foreach (var roleId in createDto.Roles)
         {
-            var role = await RoleManager.FindByIdAsync(roleId.ToString());
-            if (createDto.Roles.Contains(role.Id)) await AddUserToRole(appUser.Id, roleId);
+            await UserManager.DeleteAsync(appUser);
+            throw new KirelValidationException("Failed to add password");
         }
-
-        var claims = Mapper.Map<List<Claim>>(createDto.Claims);
-        foreach (var claim in claims) await AddClaimToUser(claim, appUser.Id);
-        var passwordResult = await UserManager.AddPasswordAsync(appUser, createDto.Password);
-        if (passwordResult.Succeeded)
-        {
-            var newUser = Mapper.Map<TUserDto>(appUser);
-            newUser.Roles = await GetUserRolesIds(appUser.Id);
-            newUser.Claims = Mapper.Map<List<TClaimDto>>(claims);
-            return newUser;
-        }
-
-        await UserManager.DeleteAsync(appUser);
-        throw new KirelValidationException("Failed to add password");
+        return Mapper.Map<TUserDto>(appUser);
     }
 
     /// <summary>
@@ -287,24 +176,19 @@ public class KirelUserService<TKey, TUser, TRole, TUserRole, TUserDto, TUserCrea
     /// <exception cref="KirelIdentityStoreException"> If user manager fails to update user </exception>
     public virtual async Task<TUserDto> UpdateUser(TKey userId, TUserUpdateDto updateDto)
     {
-        var user = await UserManager.FindByIdAsync(userId.ToString());
+        var user = await Users.FirstOrDefaultAsync(u => u.Id.Equals(userId));
         if (user == null)
             throw new KirelNotFoundException($"User with specified id {userId} was not found");
         var updatedUser = Mapper.Map(updateDto, user);
         var result = await UserManager.UpdateAsync(updatedUser);
         if (!result.Succeeded)
             throw new KirelIdentityStoreException($"Failed to update user with {userId} id");
-        await SyncUserClaims(userId, updateDto.Claims);
-        await SyncUserRoles(userId, updateDto.Roles);
         if (!string.IsNullOrEmpty(updateDto.Password))
         {
             await UserManager.RemovePasswordAsync(user);
             await UserManager.AddPasswordAsync(user, updateDto.Password);
         }
-
         var returnDto = Mapper.Map<TUserDto>(updatedUser);
-        returnDto.Claims = Mapper.Map<List<TClaimDto>>(await GetUserClaims(userId));
-        returnDto.Roles = await GetUserRolesIds(userId);
         return returnDto;
     }
 
@@ -315,43 +199,9 @@ public class KirelUserService<TKey, TUser, TRole, TUserRole, TUserDto, TUserCrea
     /// <exception cref="KirelNotFoundException"> If user with given id was not found </exception>
     public virtual async Task DeleteUser(TKey id)
     {
-        var user = await UserManager.FindByIdAsync(id.ToString());
+        var user = await Users.FirstOrDefaultAsync(u => u.Id.Equals(id));
         if (user == null)
             throw new KirelNotFoundException($"User with specified id {id} was not found");
         await UserManager.DeleteAsync(user);
-    }
-
-    /// <summary>
-    /// Adds a user to the specified role
-    /// </summary>
-    /// <param name="userId"> User id </param>
-    /// <param name="roleId"> Role id </param>
-    /// <exception cref="KirelNotFoundException"> if role or user was not found </exception>
-    public virtual async Task AddUserToRole(TKey userId, TKey roleId)
-    {
-        var role = await RoleManager.FindByIdAsync(roleId.ToString());
-        if (role == null)
-            throw new KirelNotFoundException($"Role with given id {roleId} was not found");
-        var user = await UserManager.FindByIdAsync(userId.ToString());
-        if (user == null)
-            throw new KirelNotFoundException($"User with specified id {userId} was not found");
-        await UserManager.AddToRoleAsync(user, role.Name);
-    }
-
-    /// <summary>
-    /// Deletes a user from the specified role
-    /// </summary>
-    /// <param name="userId"> User id </param>
-    /// <param name="roleId"> Role id </param>
-    /// <exception cref="KirelNotFoundException"> If role or user was not found </exception>
-    public virtual async Task DeleteUserFromRole(TKey userId, TKey roleId)
-    {
-        var role = await RoleManager.FindByIdAsync(roleId.ToString());
-        if (role == null)
-            throw new KirelNotFoundException($"Role with given id {roleId} was not found");
-        var user = await UserManager.FindByIdAsync(userId.ToString());
-        if (user == null)
-            throw new KirelNotFoundException($"User with specified id {userId} was not found");
-        await UserManager.RemoveFromRoleAsync(user, role.Name);
     }
 }

--- a/src/Kirel.Identity.Core/Services/KirelUserService.cs
+++ b/src/Kirel.Identity.Core/Services/KirelUserService.cs
@@ -4,7 +4,6 @@ using Kirel.DTO;
 using Kirel.Identity.Core.Models;
 using Kirel.Identity.DTOs;
 using Kirel.Identity.Exceptions;
-using Kirel.Shared;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
 
@@ -106,7 +105,7 @@ public class KirelUserService<TKey, TUser, TRole, TUserRole, TUserClaim, TRoleCl
             rolesIdsExpression = u => u.UserRoles.Any(d => roleIds.Contains(d.RoleId));
         
         if (!string.IsNullOrEmpty(search))
-            searchExpression = PredicateBuilder.PredicateSearchInAllFields<TUser>(search, true);
+            searchExpression = PredicateBuilder.PredicateSearchInAllFields<TUser>(search, false);
         
         if (!string.IsNullOrEmpty(orderBy)) 
             orderByFunc = ServiceHelper.GenerateOrderingMethod<TUser>(orderBy, orderDirection);

--- a/src/Kirel.Identity.Core/Services/KirelUserService.cs
+++ b/src/Kirel.Identity.Core/Services/KirelUserService.cs
@@ -1,6 +1,5 @@
 ﻿using System.Linq.Expressions;
 using AutoMapper;
-using Kirel.DTO;
 using Kirel.Identity.Core.Models;
 using Kirel.Identity.DTOs;
 using Kirel.Identity.Exceptions;
@@ -93,8 +92,8 @@ public class KirelUserService<TKey, TUser, TRole, TUserRole, TUserClaim, TRoleCl
     /// <param name="roleIds"> Id's of the roles for users filtering </param>
     /// <returns> List of users dto with pagination </returns>
     /// <exception cref="ArgumentOutOfRangeException"> If passed wrong sort direction </exception>
-    public virtual async Task<PaginatedResult<List<TUserDto>>> GetUsersList(int page, int pageSize, string search,
-        string orderBy, SortDirection orderDirection, IEnumerable<TKey>? roleIds = null)
+    public virtual async Task<PaginatedItemsDto<TUserDto>> GetUsersList(int page, int pageSize, string search,
+        string orderBy, SortDirectionDto orderDirection, IEnumerable<TKey>? roleIds = null)
     {
         page = page < 1 ? 1 : page;
         pageSize = pageSize < 1 ? 10 : pageSize;
@@ -124,7 +123,7 @@ public class KirelUserService<TKey, TUser, TRole, TUserRole, TUserClaim, TRoleCl
     /// <param name="orderBy"> Ordering method </param>
     /// <returns> List of users dto with pagination </returns>
     /// <exception cref="ArgumentOutOfRangeException"> If passed wrong sort direction </exception>
-    internal virtual async Task<PaginatedResult<List<TUserDto>>> GetUsersList(int page, int pageSize, 
+    internal virtual async Task<PaginatedItemsDto<TUserDto>> GetUsersList(int page, int pageSize, 
         Expression<Func<TUser, bool>>? filterBy,
         Func<IQueryable<TUser>, IOrderedQueryable<TUser>>? orderBy)
     {
@@ -136,12 +135,12 @@ public class KirelUserService<TKey, TUser, TRole, TUserRole, TUserClaim, TRoleCl
         
         appUsers = appUsers.Skip((page - 1) * pageSize).Take(pageSize);
         
-        var pagination = Pagination.Generate(page, pageSize, count);
+        var pagination = PaginationDto.Generate(page, pageSize, count);
         var data = Mapper.Map<List<TUserDto>>(appUsers);
-        return new PaginatedResult<List<TUserDto>>
+        return new PaginatedItemsDto<TUserDto>
         {
             Pagination = pagination,
-            Data = data
+            Items = data
         };
     }
     

--- a/src/Kirel.Identity.Core/Services/PredicateBuilder.cs
+++ b/src/Kirel.Identity.Core/Services/PredicateBuilder.cs
@@ -1,0 +1,107 @@
+﻿using System.Linq.Expressions;
+
+namespace Kirel.Identity.Core.Services;
+
+/// <summary>
+/// Class which constructs LINQ predicates piece by piece
+/// </summary>
+public class PredicateBuilder
+{
+    /// <summary>
+    /// Method for creating an Expression that initially evaluates true
+    /// </summary>
+    /// <typeparam name="T">Class type</typeparam>
+    /// <returns>Expression</returns>
+    public static Expression<Func<T, bool>> True<T>()
+    {
+        return _ => true;
+    }
+    /// <summary>
+    /// Method for creating an Expression that initially evaluates true
+    /// </summary>
+    /// <typeparam name="T">Class type</typeparam>
+    /// <returns>Expression</returns>
+    public static Expression<Func<T, bool>> False<T>()
+    {
+        return _ => false;
+    }
+    /// <summary>
+    /// Class implements a keyword search
+    /// </summary>
+    /// <param name="keyword">Searching keyword</param>
+    /// <param name="includeVirtual">Search in virtual properties flag</param>
+    /// <typeparam name="T">Class type</typeparam>
+    /// <returns>Expression</returns>
+    public static Expression<Func<T, bool>> PredicateSearchInAllFields<T>(string? keyword, bool includeVirtual = false)
+    {
+        if (string.IsNullOrEmpty(keyword))
+            return True<T>();
+        var predicate = False<T>();
+        var properties = typeof(T).GetProperties().AsEnumerable();
+        if (!includeVirtual)
+            properties = properties.Where(p => p.PropertyType == typeof(string));
+        foreach (var propertyInfo in properties)
+        {
+            var parameter = Expression.Parameter(typeof(T), "x");
+            var property = Expression.Property(parameter, propertyInfo);
+            var propertyAsObject = Expression.Convert(property, typeof(object));
+            var nullCheck = Expression.NotEqual(propertyAsObject, Expression.Constant(null, typeof(object)));
+            var propertyAsString = Expression.Call(property, "ToString", null, null);
+            var keywordExpression = Expression.Constant(keyword);
+            var contains = propertyInfo.PropertyType == typeof(string) ? 
+                Expression.Call(property, "Contains", null, keywordExpression) : 
+                Expression.Call(propertyAsString, "Contains", null, keywordExpression);
+            var lambda = Expression.Lambda(Expression.AndAlso(nullCheck, contains), parameter);
+            predicate = Or(predicate, (Expression<Func<T, bool>>)lambda);
+        }
+
+        return predicate;
+    }
+    /// <summary>
+    /// Wrapping in a new lambda expression
+    /// </summary>
+    /// <param name="propertyName">Property name</param>
+    /// <param name="includeVirtual">Search in virtual properties flag</param>
+    /// <typeparam name="T">Class type</typeparam>
+    /// <returns>Expression</returns>
+    public static Expression<Func<T, object>>? ToLambda<T>(string? propertyName, bool includeVirtual = true)
+    {
+        if (!includeVirtual && typeof(T)
+            .GetProperties().Any(p => p.GetGetMethod()?.IsVirtual is false &&
+                                      p.Name.Equals(propertyName, StringComparison.OrdinalIgnoreCase)))
+            return null;
+
+        if (string.IsNullOrWhiteSpace(propertyName))
+            return null;
+        
+        var parameter = Expression.Parameter(typeof(T));
+        var property = Expression.Property(parameter, propertyName);
+        var propAsObject = Expression.Convert(property, typeof(object));
+
+        return Expression.Lambda<Func<T, object>>(propAsObject, parameter);
+    }
+    /// <summary>
+    /// Or conditions method
+    /// </summary>
+    /// <param name="expr1">First expression</param>
+    /// <param name="expr2">Second expression</param>
+    /// <typeparam name="T">Class type</typeparam>
+    /// <returns>Expression</returns>
+    public static Expression<Func<T, bool>> Or<T>(Expression<Func<T, bool>> expr1, Expression<Func<T, bool>> expr2)
+    {
+        var invokedExpr = Expression.Invoke(expr2, expr1.Parameters.Cast<Expression>());
+        return Expression.Lambda<Func<T, bool>>(Expression.OrElse(expr1.Body, invokedExpr), expr1.Parameters);
+    }
+    /// <summary>
+    /// And conditions method
+    /// </summary>
+    /// <param name="expr1">First expression</param>
+    /// <param name="expr2">Second expression</param>
+    /// <typeparam name="T">Class type</typeparam>
+    /// <returns>Expression</returns>
+    public static Expression<Func<T, bool>> And<T>(Expression<Func<T, bool>> expr1, Expression<Func<T, bool>> expr2)
+    {
+        var invokedExpr = Expression.Invoke(expr2, expr1.Parameters.Cast<Expression>());
+        return Expression.Lambda<Func<T, bool>>(Expression.AndAlso(expr1.Body, invokedExpr), expr1.Parameters);
+    }
+}

--- a/src/Kirel.Identity.Core/Services/ServiceHelper.cs
+++ b/src/Kirel.Identity.Core/Services/ServiceHelper.cs
@@ -1,5 +1,5 @@
 ﻿using System.Linq.Expressions;
-using Kirel.DTO;
+using Kirel.Identity.DTOs;
 
 namespace Kirel.Identity.Core.Services;
 
@@ -15,7 +15,7 @@ public static class ServiceHelper
     /// <param name="orderDirection"> Order direction </param>
     /// <typeparam name="TEntity"> Entity type </typeparam>
     /// <returns>Ordering function</returns>
-    public static Func<IQueryable<TEntity>, IOrderedQueryable<TEntity>>? GenerateOrderingMethod<TEntity>(string? orderBy, SortDirection orderDirection)
+    public static Func<IQueryable<TEntity>, IOrderedQueryable<TEntity>>? GenerateOrderingMethod<TEntity>(string? orderBy, SortDirectionDto orderDirection)
     {
         Func<IQueryable<TEntity>, IOrderedQueryable<TEntity>>? orderingMethod = null;
         if (string.IsNullOrEmpty(orderBy)) return null;
@@ -23,10 +23,10 @@ public static class ServiceHelper
         if (orderExpression == null) return orderingMethod;
         switch (orderDirection)
         {
-            case SortDirection.Asc:
+            case SortDirectionDto.Asc:
                 orderingMethod = o => o.OrderBy(orderExpression);
                 break;
-            case SortDirection.Desc:
+            case SortDirectionDto.Desc:
                 orderingMethod = o => o.OrderByDescending(orderExpression);
                 break;
         }

--- a/src/Kirel.Identity.Core/Services/ServiceHelper.cs
+++ b/src/Kirel.Identity.Core/Services/ServiceHelper.cs
@@ -1,6 +1,5 @@
 ﻿using System.Linq.Expressions;
 using Kirel.DTO;
-using Kirel.Shared;
 
 namespace Kirel.Identity.Core.Services;
 

--- a/src/Kirel.Identity.Core/Validators/KirelRoleCreateDtoValidator.cs
+++ b/src/Kirel.Identity.Core/Validators/KirelRoleCreateDtoValidator.cs
@@ -9,13 +9,15 @@ namespace Kirel.Identity.Core.Validators;
 /// Validation for KirelRoleCreateDto
 /// </summary>
 public class
-    KirelRoleCreateDtoValidator<TKey, TRole, TUser, TUserRole, TRoleCreateDto, TClaimCreateDto> : AbstractValidator<TRoleCreateDto>
+    KirelRoleCreateDtoValidator<TKey, TRole, TUser, TUserRole, TRoleClaim, TUserClaim, TRoleCreateDto, TClaimCreateDto> : AbstractValidator<TRoleCreateDto>
     where TKey : IComparable, IComparable<TKey>, IEquatable<TKey>
-    where TUser : KirelIdentityUser<TKey, TUser, TRole, TUserRole>
-    where TRole : KirelIdentityRole<TKey, TRole, TUser, TUserRole>
-    where TUserRole : KirelIdentityUserRole<TKey, TUserRole, TUser, TRole>
+    where TUser : KirelIdentityUser<TKey, TUser, TRole, TUserRole, TUserClaim, TRoleClaim>
+    where TRole : KirelIdentityRole<TKey, TRole, TUser, TUserRole, TRoleClaim, TUserClaim>
+    where TUserRole : KirelIdentityUserRole<TKey, TUserRole, TUser, TRole, TUserClaim, TRoleClaim>
     where TRoleCreateDto : KirelRoleCreateDto<TClaimCreateDto>
     where TClaimCreateDto : KirelClaimCreateDto
+    where TRoleClaim : KirelIdentityRoleClaim<TKey>
+    where TUserClaim : KirelIdentityUserClaim<TKey>
 {
     private readonly RoleManager<TRole> _roleManager;
 

--- a/src/Kirel.Identity.Core/Validators/KirelRoleUpdateDtoValidator.cs
+++ b/src/Kirel.Identity.Core/Validators/KirelRoleUpdateDtoValidator.cs
@@ -11,13 +11,15 @@ namespace Kirel.Identity.Core.Validators;
 /// Validation for KirelRoleUpdateDto
 /// </summary>
 public class
-    KirelRoleUpdateDtoValidator<TKey, TRole, TUser, TUserRole, TRoleUpdateDto, TClaimUpdateDto> : AbstractValidator<TRoleUpdateDto>
+    KirelRoleUpdateDtoValidator<TKey, TRole, TUser, TUserRole, TRoleClaim, TUserClaim, TRoleUpdateDto, TClaimUpdateDto> : AbstractValidator<TRoleUpdateDto>
     where TKey : IComparable, IComparable<TKey>, IEquatable<TKey>
-    where TUser : KirelIdentityUser<TKey, TUser, TRole, TUserRole>
-    where TRole : KirelIdentityRole<TKey, TRole, TUser, TUserRole>
-    where TUserRole : KirelIdentityUserRole<TKey, TUserRole, TUser, TRole>
+    where TUser : KirelIdentityUser<TKey, TUser, TRole, TUserRole, TUserClaim, TRoleClaim>
+    where TRole : KirelIdentityRole<TKey, TRole, TUser, TUserRole, TRoleClaim, TUserClaim>
+    where TUserRole : KirelIdentityUserRole<TKey, TUserRole, TUser, TRole, TUserClaim, TRoleClaim>
     where TRoleUpdateDto : KirelRoleUpdateDto<TClaimUpdateDto>
     where TClaimUpdateDto : KirelClaimUpdateDto
+    where TRoleClaim : KirelIdentityRoleClaim<TKey>
+    where TUserClaim : KirelIdentityUserClaim<TKey>
 {
     private readonly IHttpContextAccessor _httpContextAccessor;
     private readonly RoleManager<TRole> _roleManager;

--- a/src/Kirel.Identity.Core/Validators/KirelUserCreateDtoValidator.cs
+++ b/src/Kirel.Identity.Core/Validators/KirelUserCreateDtoValidator.cs
@@ -11,13 +11,15 @@ namespace Kirel.Identity.Core.Validators;
 /// Validation for KirelUserCreateDto
 /// </summary>
 public class
-    KirelUserCreateDtoValidator<TKey, TUser, TRole, TUserRole, TUserCreateDto, TClaimCreateDto> : AbstractValidator<TUserCreateDto>
+    KirelUserCreateDtoValidator<TKey, TUser, TRole, TUserRole, TUserClaim, TRoleClaim, TUserCreateDto, TClaimCreateDto> : AbstractValidator<TUserCreateDto>
     where TKey : IComparable, IComparable<TKey>, IEquatable<TKey>
-    where TUser : KirelIdentityUser<TKey, TUser, TRole, TUserRole>
-    where TRole : KirelIdentityRole<TKey, TRole, TUser, TUserRole>
-    where TUserRole : KirelIdentityUserRole<TKey, TUserRole, TUser, TRole>
+    where TUser : KirelIdentityUser<TKey, TUser, TRole, TUserRole, TUserClaim, TRoleClaim>
+    where TRole : KirelIdentityRole<TKey, TRole, TUser, TUserRole, TRoleClaim, TUserClaim>
+    where TUserRole : KirelIdentityUserRole<TKey, TUserRole, TUser, TRole, TUserClaim, TRoleClaim>
     where TUserCreateDto : KirelUserCreateDto<TKey, TClaimCreateDto>
     where TClaimCreateDto : KirelClaimCreateDto
+    where TRoleClaim : KirelIdentityRoleClaim<TKey>
+    where TUserClaim : KirelIdentityUserClaim<TKey>
 {
     private readonly RoleManager<TRole> _roleManager;
     private readonly UserManager<TUser> _userManager;

--- a/src/Kirel.Identity.Core/Validators/KirelUserRegistrationDtoValidator.cs
+++ b/src/Kirel.Identity.Core/Validators/KirelUserRegistrationDtoValidator.cs
@@ -10,11 +10,13 @@ namespace Kirel.Identity.Core.Validators;
 /// <summary>
 /// Validation for KirelUserRegistrationDto
 /// </summary>
-public class KirelUserRegistrationDtoValidator<TKey, TUser, TRole, TUserRole> : AbstractValidator<KirelUserRegistrationDto>
+public class KirelUserRegistrationDtoValidator<TKey, TUser, TRole, TUserRole, TUserClaim, TRoleClaim> : AbstractValidator<KirelUserRegistrationDto>
     where TKey : IComparable, IComparable<TKey>, IEquatable<TKey>
-    where TUser : KirelIdentityUser<TKey, TUser, TRole, TUserRole>
-    where TRole : KirelIdentityRole<TKey, TRole, TUser, TUserRole>
-    where TUserRole : KirelIdentityUserRole<TKey, TUserRole, TUser, TRole>
+    where TUser : KirelIdentityUser<TKey, TUser, TRole, TUserRole, TUserClaim, TRoleClaim>
+    where TRole : KirelIdentityRole<TKey, TRole, TUser, TUserRole, TRoleClaim, TUserClaim>
+    where TUserRole : KirelIdentityUserRole<TKey, TUserRole, TUser, TRole, TUserClaim, TRoleClaim>
+    where TRoleClaim : KirelIdentityRoleClaim<TKey>
+    where TUserClaim : KirelIdentityUserClaim<TKey>
 {
     private readonly UserManager<TUser> _userManager;
 

--- a/src/Kirel.Identity.Core/Validators/KirelUserUpdateDtoValidator.cs
+++ b/src/Kirel.Identity.Core/Validators/KirelUserUpdateDtoValidator.cs
@@ -13,13 +13,15 @@ namespace Kirel.Identity.Core.Validators;
 /// Validation class for user update dto
 /// </summary>
 public class
-    KirelUserUpdateDtoValidator<TKey, TUser, TRole, TUserRole, TUserUpdateDto, TClaimUpdateDto> : AbstractValidator<TUserUpdateDto>
+    KirelUserUpdateDtoValidator<TKey, TUser, TRole, TUserRole, TUserClaim, TRoleClaim, TUserUpdateDto, TClaimUpdateDto> : AbstractValidator<TUserUpdateDto>
     where TKey : IComparable, IComparable<TKey>, IEquatable<TKey>
-    where TUser : KirelIdentityUser<TKey, TUser, TRole, TUserRole>
-    where TRole : KirelIdentityRole<TKey, TRole, TUser, TUserRole>
-    where TUserRole : KirelIdentityUserRole<TKey, TUserRole, TUser, TRole>
+    where TUser : KirelIdentityUser<TKey, TUser, TRole, TUserRole, TUserClaim, TRoleClaim>
+    where TRole : KirelIdentityRole<TKey, TRole, TUser, TUserRole, TRoleClaim, TUserClaim>
+    where TUserRole : KirelIdentityUserRole<TKey, TUserRole, TUser, TRole, TUserClaim, TRoleClaim>
     where TUserUpdateDto : KirelUserUpdateDto<TKey, TClaimUpdateDto>
     where TClaimUpdateDto : KirelClaimUpdateDto
+    where TRoleClaim : KirelIdentityRoleClaim<TKey>
+    where TUserClaim : KirelIdentityUserClaim<TKey>
 {
     private readonly IHttpContextAccessor _httpContextAccessor;
     private readonly RoleManager<TRole> _roleManager;

--- a/src/Kirel.Identity.DTOs/PaginatedItemsDto.cs
+++ b/src/Kirel.Identity.DTOs/PaginatedItemsDto.cs
@@ -1,0 +1,94 @@
+﻿namespace Kirel.Identity.DTOs;
+
+/// <summary>
+/// Pagination info 
+/// </summary>
+public class PaginationDto
+{
+    /// <summary>
+    /// Total number of pages
+    /// </summary>
+    public int TotalPages { get; set; }
+    /// <summary>
+    /// Total number of items
+    /// </summary>
+    public int TotalCount { get; set; }
+    /// <summary>
+    /// Current page number
+    /// </summary>
+    public int Page { get; set; }
+    /// <summary>
+    /// Size of the page
+    /// </summary>
+    public int Size { get; set; }
+    /// <summary>
+    /// Pagination constructor
+    /// </summary>
+    /// <param name="totalPages">Total number of pages</param>
+    /// <param name="totalCount">Total number of items</param>
+    /// <param name="page">Current page number</param>
+    /// <param name="size">Size of the page</param>
+    public PaginationDto(int totalPages = 0, int totalCount = 0, int page = 1, int size = 10)
+    {
+        TotalPages = totalPages;
+        TotalCount = totalCount;
+        Page = page;
+        Size = size;
+    }
+    
+    /// <summary>
+    /// Generates pagination of entities
+    /// </summary>
+    /// <param name="pageNumber">Page number</param>
+    /// <param name="pageSize">Page size</param>
+    /// <param name="totalCount">Total count</param>
+    /// <returns>Pagination</returns>
+    public static PaginationDto Generate(int pageNumber = 0, int pageSize = 0, int totalCount = 0)
+    {
+        var page = pageNumber > 0 ? pageNumber : 1;
+        var size = pageSize > 0 ? pageSize : 10;
+        var pagination = new PaginationDto()
+        {
+            Page = page,
+            Size = size,
+            TotalCount = totalCount,
+            TotalPages = (int) Math.Ceiling(totalCount / (double) size)
+        };
+        return pagination;
+    }
+}
+/// <summary>
+/// Paginated items data
+/// </summary>
+/// <typeparam name="T">Entity type</typeparam>
+public class PaginatedItemsDto<T>
+{
+    /// <summary>
+    /// Pagination entity field
+    /// </summary>
+    public PaginationDto Pagination { get; set; }
+    /// <summary>
+    /// Items list
+    /// </summary>
+    public List<T>? Items { get; set; }
+    /// <summary>
+    /// PaginatedResult constructor
+    /// </summary>
+    public PaginatedItemsDto()
+    {
+        Pagination = new PaginationDto();
+    }
+    /// <summary>
+    /// PaginatedResult constructor
+    /// </summary>
+    /// <param name="items"> List of paginated elements </param>
+    /// <param name="page">Current page number</param>
+    /// <param name="size">Size of the page</param>
+    /// <param name="totalPages">Total number of pages</param>
+    /// <param name="totalCount">Total number of items</param>
+    public PaginatedItemsDto(List<T> items, int page, int size, int totalPages, int totalCount)
+    {
+        Pagination = new PaginationDto(totalPages, totalCount, page: page, size: size);
+        Items = items;
+    }
+}

--- a/src/Kirel.Identity.DTOs/SortDirectionDto.cs
+++ b/src/Kirel.Identity.DTOs/SortDirectionDto.cs
@@ -1,0 +1,16 @@
+﻿namespace Kirel.Identity.DTOs;
+
+/// <summary>
+/// Sort direction dto
+/// </summary>
+public enum SortDirectionDto
+{
+    /// <summary>
+    /// Ascending sort
+    /// </summary>
+    Asc,
+    /// <summary>
+    /// Descending sort
+    /// </summary>
+    Desc
+}

--- a/src/Kirel.Identity.Jwt.Controllers/KirelJwtAuthenticationController.cs
+++ b/src/Kirel.Identity.Jwt.Controllers/KirelJwtAuthenticationController.cs
@@ -27,17 +27,21 @@ namespace Kirel.Identity.Jwt.Controllers;
 /// <typeparam name="TAuthorizedUserDto"> </typeparam>
 /// <typeparam name="TAuthorizedUserUpdateDto"> </typeparam>
 /// <typeparam name="TUserRole"> The user role entity type </typeparam>
+/// <typeparam name="TUserClaim"> User claim type. </typeparam>
+/// <typeparam name="TRoleClaim"> Role claim type. </typeparam>
 public class KirelJwtAuthenticationController<TTokenService, TAuthenticationService, TAuthorizedUserService,
-    TKey, TUser, TRole, TUserRole, TAuthorizedUserDto, TAuthorizedUserUpdateDto> : Controller
+    TKey, TUser, TRole, TUserRole, TUserClaim, TRoleClaim, TAuthorizedUserDto, TAuthorizedUserUpdateDto> : Controller
     where TKey : IComparable, IComparable<TKey>, IEquatable<TKey>
-    where TUser : KirelIdentityUser<TKey, TUser, TRole, TUserRole>
-    where TRole : KirelIdentityRole<TKey, TRole, TUser, TUserRole>
-    where TUserRole : KirelIdentityUserRole<TKey, TUserRole, TUser, TRole>
+    where TUser : KirelIdentityUser<TKey, TUser, TRole, TUserRole, TUserClaim, TRoleClaim>
+    where TRole : KirelIdentityRole<TKey, TRole, TUser, TUserRole, TRoleClaim, TUserClaim>
+    where TUserRole : KirelIdentityUserRole<TKey, TUserRole, TUser, TRole, TUserClaim, TRoleClaim>
+    where TRoleClaim : KirelIdentityRoleClaim<TKey>
+    where TUserClaim : KirelIdentityUserClaim<TKey>
     where TAuthorizedUserDto : KirelAuthorizedUserDto
     where TAuthorizedUserUpdateDto : KirelAuthorizedUserUpdateDto
-    where TTokenService : KirelJwtTokenService<TKey, TUser, TRole, TUserRole>
-    where TAuthenticationService : KirelAuthenticationService<TKey, TUser, TRole, TUserRole>
-    where TAuthorizedUserService : KirelAuthorizedUserService<TKey, TUser, TRole, TUserRole, TAuthorizedUserDto, TAuthorizedUserUpdateDto>
+    where TTokenService : KirelJwtTokenService<TKey, TUser, TRole, TUserRole, TUserClaim, TRoleClaim>
+    where TAuthenticationService : KirelAuthenticationService<TKey, TUser, TRole, TUserRole, TUserClaim, TRoleClaim>
+    where TAuthorizedUserService : KirelAuthorizedUserService<TKey, TUser, TRole, TUserRole, TUserClaim, TRoleClaim, TAuthorizedUserDto, TAuthorizedUserUpdateDto>
 {
     /// <summary>
     /// Authentication service

--- a/src/Kirel.Identity.Server.API/Claims/ClaimsControllersGetter.cs
+++ b/src/Kirel.Identity.Server.API/Claims/ClaimsControllersGetter.cs
@@ -1,0 +1,41 @@
+﻿using System.Security.Claims;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Authorization.Infrastructure;
+using Microsoft.AspNetCore.Mvc.Controllers;
+using Microsoft.AspNetCore.Mvc.Infrastructure;
+
+namespace Kirel.Identity.Server.API.Claims;
+
+/// <summary>
+/// Simple static helper for get all controllers claims in current runtime
+/// </summary>
+public static class ClaimsControllersGetter
+{
+    /// <summary>
+    /// Get all claim policies from controllers descriptions
+    /// </summary>
+    /// <param name="authorizationPolicyCollectionProvider"></param>
+    /// <param name="actionDescriptorCollectionProvider"></param>
+    /// <returns></returns>
+    public static List<Claim> GetControllersClaimsFromPolicies(IAuthorizationPolicyProvider authorizationPolicyCollectionProvider,
+        IActionDescriptorCollectionProvider actionDescriptorCollectionProvider)
+    {
+        var claims = new List<Claim>();
+        var actionDescriptors = actionDescriptorCollectionProvider.ActionDescriptors.Items;
+        foreach (var controllerActionDescriptor in actionDescriptors.OfType<ControllerActionDescriptor>())
+        {
+            foreach (var authorizeAttribute in controllerActionDescriptor.EndpointMetadata.OfType<AuthorizeAttribute>()
+                         .Where(a => !string.IsNullOrEmpty(a.Policy)))
+            {
+                var policy = authorizationPolicyCollectionProvider
+                    .GetPolicyAsync(authorizeAttribute.Policy!).Result;
+                foreach (var requirement in policy!.Requirements.OfType<ClaimsAuthorizationRequirement>()
+                             .Where(r => r.AllowedValues != null))
+                {
+                    claims.AddRange(requirement.AllowedValues!.Select(v => new Claim(requirement.ClaimType, v)));
+                }
+            }
+        }
+        return claims;
+    }
+}

--- a/src/Kirel.Identity.Server.API/Configs/ClaimConfig.cs
+++ b/src/Kirel.Identity.Server.API/Configs/ClaimConfig.cs
@@ -1,0 +1,16 @@
+﻿namespace Kirel.Identity.Server.API.Configs;
+
+/// <summary>
+/// Configuration for create claim
+/// </summary>
+public class ClaimConfig
+{
+    /// <summary>
+    /// Claim type
+    /// </summary>
+    public string Type { get; set; } = "";
+    /// <summary>
+    /// Claim value
+    /// </summary>
+    public string Value { get; set; } = "";
+}

--- a/src/Kirel.Identity.Server.API/Configs/DataSeedConfig.cs
+++ b/src/Kirel.Identity.Server.API/Configs/DataSeedConfig.cs
@@ -10,7 +10,7 @@ public class IdentityDataSeedConfig
     /// <summary>
     /// Gets or sets the list of role configurations.
     /// </summary>
-    public List<string> Roles { get; set; } = new();
+    public List<RoleConfig> Roles { get; set; } = new();
 
     /// <summary>
     /// Gets or sets the list of user configurations.

--- a/src/Kirel.Identity.Server.API/Configs/RoleConfig.cs
+++ b/src/Kirel.Identity.Server.API/Configs/RoleConfig.cs
@@ -1,0 +1,16 @@
+﻿namespace Kirel.Identity.Server.API.Configs;
+
+/// <summary>
+/// Configuration class for Role creation
+/// </summary>
+public class RoleConfig
+{
+    /// <summary>
+    /// Role name
+    /// </summary>
+    public string Name { get; set; }
+    /// <summary>
+    /// Claims list of the role
+    /// </summary>
+    public List<ClaimConfig> Claims { get; set; } = new();
+}

--- a/src/Kirel.Identity.Server.API/Configs/UserConfig.cs
+++ b/src/Kirel.Identity.Server.API/Configs/UserConfig.cs
@@ -34,4 +34,8 @@ public class UserConfig
     /// Gets or sets the list of roles associated with the user.
     /// </summary>
     public List<string> Roles { get; set; } = new();
+    /// <summary>
+    /// Claims of this user
+    /// </summary>
+    public List<ClaimConfig> Claims { get; set; } = new();
 }

--- a/src/Kirel.Identity.Server.API/Controllers/AuthorizedUserController.cs
+++ b/src/Kirel.Identity.Server.API/Controllers/AuthorizedUserController.cs
@@ -12,7 +12,7 @@ namespace Kirel.Identity.Server.API.Controllers;
 [ApiController]
 [Authorize]
 [Route("authorized/user")]
-public class AuthorizedUserController : KirelAuthorizedUserController<AuthorizedUserService, Guid, User, Role, UserRole,
+public class AuthorizedUserController : KirelAuthorizedUserController<AuthorizedUserService, Guid, User, Role, UserRole, UserClaim, RoleClaim,
     AuthorizedUserDto, AuthorizedUserUpdateDto>
 {
     /// <inheritdoc />

--- a/src/Kirel.Identity.Server.API/Controllers/JwtTokenController.cs
+++ b/src/Kirel.Identity.Server.API/Controllers/JwtTokenController.cs
@@ -10,7 +10,7 @@ namespace Kirel.Identity.Server.API.Controllers;
 [Route("authentication/jwt")]
 [ApiController]
 public class AuthenticationController : KirelJwtAuthenticationController<JwtTokenService, AuthenticationService,
-    AuthorizedUserService, Guid, User, Role, UserRole, AuthorizedUserDto, AuthorizedUserUpdateDto>
+    AuthorizedUserService, Guid, User, Role, UserRole, UserClaim, RoleClaim, AuthorizedUserDto, AuthorizedUserUpdateDto>
 {
     /// <inheritdoc />
     public AuthenticationController(AuthenticationService authService, JwtTokenService tokenService,

--- a/src/Kirel.Identity.Server.API/Controllers/RegistrationController.cs
+++ b/src/Kirel.Identity.Server.API/Controllers/RegistrationController.cs
@@ -10,7 +10,7 @@ namespace Kirel.Identity.Server.API.Controllers;
 
 [ApiController]
 [Route("registration")]
-public class RegistrationController : KirelRegistrationController<RegistrationService, UserRegistrationDto, Guid, User, Role, UserRole>
+public class RegistrationController : KirelRegistrationController<RegistrationService, UserRegistrationDto, Guid, User, Role, UserRole, UserClaim, RoleClaim>
 {
     /// <inheritdoc />
     public RegistrationController(RegistrationService service) : base(service)

--- a/src/Kirel.Identity.Server.API/Controllers/RolesController.cs
+++ b/src/Kirel.Identity.Server.API/Controllers/RolesController.cs
@@ -9,7 +9,7 @@ namespace Kirel.Identity.Server.API.Controllers;
 /// <inheritdoc />
 [Route("roles")]
 [ApiController]
-public class RolesController : KirelRolesController<RoleService, Guid, Role, User, UserRole, RoleDto, RoleCreateDto, RoleUpdateDto,
+public class RolesController : KirelRolesController<RoleService, Guid, Role, User, UserRole, RoleClaim, UserClaim, RoleDto, RoleCreateDto, RoleUpdateDto,
     ClaimDto, ClaimCreateDto, ClaimUpdateDto>
 {
     /// <inheritdoc />

--- a/src/Kirel.Identity.Server.API/Controllers/UsersController.cs
+++ b/src/Kirel.Identity.Server.API/Controllers/UsersController.cs
@@ -9,7 +9,7 @@ namespace Kirel.Identity.Server.API.Controllers;
 /// <inheritdoc />
 [Route("users")]
 [ApiController]
-public class UsersController : KirelUsersController<UserService, Guid, User, Role, UserRole, UserDto, UserCreateDto, UserUpdateDto
+public class UsersController : KirelUsersController<UserService, Guid, User, Role, UserRole, UserClaim, RoleClaim, UserDto, UserCreateDto, UserUpdateDto
     , ClaimDto, ClaimCreateDto, ClaimUpdateDto>
 {
     /// <inheritdoc />

--- a/src/Kirel.Identity.Server.API/Extensions/MaintenanceExtension.cs
+++ b/src/Kirel.Identity.Server.API/Extensions/MaintenanceExtension.cs
@@ -18,12 +18,16 @@ public static class MaintenanceExtension
     /// <typeparam name="TUser"> User entity type. </typeparam>
     /// <typeparam name="TRole"> Role entity type. </typeparam>
     /// <typeparam name="TUserRole"> Role user entity type. </typeparam>
-    public static async Task MaintenanceAsync<TKey, TUser, TRole, TUserRole>(
+    /// <typeparam name="TUserClaim"> User claim type. </typeparam>
+    /// <typeparam name="TRoleClaim"> Role claim type. </typeparam>
+    public static async Task MaintenanceAsync<TKey, TUser, TRole, TUserRole, TUserClaim, TRoleClaim>(
         this IApplicationBuilder app, MaintenanceConfig config)
-        where TRole : KirelIdentityRole<TKey, TRole, TUser, TUserRole>, new ()
-        where TUser : KirelIdentityUser<TKey, TUser, TRole, TUserRole>, new ()
         where TKey : IComparable, IComparable<TKey>, IEquatable<TKey>
-        where TUserRole : KirelIdentityUserRole<TKey, TUserRole, TUser, TRole>
+        where TUser : KirelIdentityUser<TKey, TUser, TRole, TUserRole, TUserClaim, TRoleClaim>, new()
+        where TRole : KirelIdentityRole<TKey, TRole, TUser, TUserRole, TRoleClaim, TUserClaim>, new()
+        where TUserRole : KirelIdentityUserRole<TKey, TUserRole, TUser, TRole, TUserClaim, TRoleClaim>
+        where TRoleClaim : KirelIdentityRoleClaim<TKey>
+        where TUserClaim : KirelIdentityUserClaim<TKey>
     {
         var scopedServiceProvider = app.ApplicationServices.GetRequiredService<IServiceScopeFactory>().CreateScope()
             .ServiceProvider;

--- a/src/Kirel.Identity.Server.API/Extensions/UsersAndRolesDataSeedExtension.cs
+++ b/src/Kirel.Identity.Server.API/Extensions/UsersAndRolesDataSeedExtension.cs
@@ -18,11 +18,15 @@ public static class UsersAndRolesDataSeedExtension
     /// <typeparam name="TUser"> User entity type. </typeparam>
     /// <typeparam name="TRole"> Role entity type. </typeparam>
     /// <typeparam name="TUserRole"> Role user entity type. </typeparam>
-    public static async Task UsersAndRolesDataSeedAsync<TKey, TUser, TRole, TUserRole>(this IApplicationBuilder app, IdentityDataSeedConfig config)
-        where TRole : KirelIdentityRole<TKey, TRole, TUser, TUserRole>, new ()
-        where TUser : KirelIdentityUser<TKey, TUser, TRole, TUserRole>, new ()
+    /// <typeparam name="TUserClaim"> User claim type. </typeparam>
+    /// <typeparam name="TRoleClaim"> Role claim type. </typeparam>
+    public static async Task UsersAndRolesDataSeedAsync<TKey, TUser, TRole, TUserRole, TUserClaim, TRoleClaim>(this IApplicationBuilder app, IdentityDataSeedConfig config)
         where TKey : IComparable, IComparable<TKey>, IEquatable<TKey>
-        where TUserRole : KirelIdentityUserRole<TKey, TUserRole, TUser, TRole>
+        where TUser : KirelIdentityUser<TKey, TUser, TRole, TUserRole, TUserClaim, TRoleClaim>, new()
+        where TRole : KirelIdentityRole<TKey, TRole, TUser, TUserRole, TRoleClaim, TUserClaim>, new()
+        where TUserRole : KirelIdentityUserRole<TKey, TUserRole, TUser, TRole, TUserClaim, TRoleClaim>
+        where TRoleClaim : KirelIdentityRoleClaim<TKey>
+        where TUserClaim : KirelIdentityUserClaim<TKey>
     {
         const string dataSeedLockfile = "identity_data_seed.lock";
         if (File.Exists(dataSeedLockfile)) return;

--- a/src/Kirel.Identity.Server.API/Handlers/ApiKeyAuthenticationHandler.cs
+++ b/src/Kirel.Identity.Server.API/Handlers/ApiKeyAuthenticationHandler.cs
@@ -1,6 +1,11 @@
 ﻿using System.Security.Claims;
 using System.Text.Encodings.Web;
+using Kirel.Identity.Server.API.Claims;
 using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Authorization.Infrastructure;
+using Microsoft.AspNetCore.Mvc.Controllers;
+using Microsoft.AspNetCore.Mvc.Infrastructure;
 using Microsoft.Extensions.Options;
 
 namespace Kirel.Identity.Server.API.Handlers;
@@ -19,7 +24,8 @@ public class ApiKeysList : List<string>
 public class ApiKeyAuthenticationHandler : AuthenticationHandler<AuthenticationSchemeOptions>
 {
     private readonly ApiKeysList _apiKeys;
-
+    private readonly List<Claim> _claims;
+    
     /// <summary>
     /// Returns instance of api key authentication handler
     /// </summary>
@@ -28,9 +34,15 @@ public class ApiKeyAuthenticationHandler : AuthenticationHandler<AuthenticationS
     /// <param name="encoder">The <see cref="System.Text.Encodings.Web.UrlEncoder"/>.</param>
     /// <param name="clock">The <see cref="ISystemClock"/>.</param>
     /// <param name="apiKeys">List of API keys</param>
-    public ApiKeyAuthenticationHandler(IOptionsMonitor<AuthenticationSchemeOptions> options, ILoggerFactory logger, UrlEncoder encoder, ISystemClock clock, ApiKeysList apiKeys) : base(options, logger, encoder, clock)
+    /// <param name="authorizationPolicyCollectionProvider"></param>
+    /// <param name="actionDescriptorCollectionProvider"></param>
+    public ApiKeyAuthenticationHandler(IOptionsMonitor<AuthenticationSchemeOptions> options, ILoggerFactory logger, 
+        UrlEncoder encoder, ISystemClock clock, ApiKeysList apiKeys, 
+        IAuthorizationPolicyProvider authorizationPolicyCollectionProvider,
+        IActionDescriptorCollectionProvider actionDescriptorCollectionProvider) : base(options, logger, encoder, clock)
     {
         _apiKeys = apiKeys;
+        _claims = ClaimsControllersGetter.GetControllersClaimsFromPolicies(authorizationPolicyCollectionProvider, actionDescriptorCollectionProvider);
     }
 
     /// <inheritdoc />
@@ -65,17 +77,14 @@ public class ApiKeyAuthenticationHandler : AuthenticationHandler<AuthenticationS
             return AuthenticateResult.Fail("Unauthorized"); 
         }
         var identity = GetClaimsIdentity();
-        var principal = new System.Security.Principal.GenericPrincipal(identity, new []{"Microservice"});
+        var principal = new System.Security.Principal.GenericPrincipal(identity, null);
         return AuthenticateResult.Success(new AuthenticationTicket(principal, "APIKey"));
     }
     
     private ClaimsIdentity GetClaimsIdentity()
     {
-        var claims = new List<Claim>
-        {
-            new (ClaimsIdentity.DefaultNameClaimType, "Microservice"),
-        };
-        
+        var claims = new List<Claim> { new (ClaimsIdentity.DefaultNameClaimType, "Microservice")};
+        claims.AddRange(_claims);
         var claimsIdentity =
             new ClaimsIdentity(claims, "APIKey", ClaimsIdentity.DefaultNameClaimType,
                 ClaimsIdentity.DefaultRoleClaimType);

--- a/src/Kirel.Identity.Server.API/Program.cs
+++ b/src/Kirel.Identity.Server.API/Program.cs
@@ -1,3 +1,4 @@
+using Kirel.Identity.Controllers.Extensions;
 using Kirel.Identity.Middlewares;
 using Kirel.Identity.Server.API.Configs;
 using Kirel.Identity.Server.API.Controllers;
@@ -57,6 +58,7 @@ builder.Services.AddControllers(options =>
 
 // Add ASP.NET authentication configuration
 builder.Services.AddAuthenticationConfiguration(jwtConfig, apiKeys);
+builder.Services.AddClaimBasedAuthorization();
 
 // Add custom swagger configuration
 builder.Services.AddSwagger(disabledControllers);

--- a/src/Kirel.Identity.Server.API/Program.cs
+++ b/src/Kirel.Identity.Server.API/Program.cs
@@ -78,9 +78,9 @@ var app = builder.Build();
 // Apply migrations to db
 await app.MigrateIdentityDbAsync();
 // Create admin user and role, do maintenance admin password reset if needed
-await app.MaintenanceAsync<Guid, User, Role, UserRole>(maintenanceConfig);
+await app.MaintenanceAsync<Guid, User, Role, UserRole, UserClaim, RoleClaim>(maintenanceConfig);
 // Apply users and roles data seeding
-await app.UsersAndRolesDataSeedAsync<Guid, User, Role, UserRole>(dataSeedConfig);
+await app.UsersAndRolesDataSeedAsync<Guid, User, Role, UserRole, UserClaim, RoleClaim>(dataSeedConfig);
 
 // Configure the HTTP request pipeline.
 if (app.Environment.IsDevelopment())

--- a/src/Kirel.Identity.Server.API/appsettings.Development.json
+++ b/src/Kirel.Identity.Server.API/appsettings.Development.json
@@ -5,6 +5,7 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
+  "AllowedHosts": "*",
   "dbConfig": {
     "Driver": "sqlite",
     "Params": {
@@ -21,40 +22,72 @@
       "Password": "Admin@123"
     }
   },
-  "APIKeys": [
-    "TestAPIKEY1"
-  ],
+  "DataSeeding": {
+    "Roles": [
+      {
+        "Name": "RoleManager",
+        "Claims" : [
+          {
+            "Type": "role_claim",
+            "Value": "read"
+          },
+          {
+            "Type": "role_claim",
+            "Value": "create"
+          },
+          {
+            "Type": "role_claim",
+            "Value": "update"
+          }
+        ]
+      },
+      {
+        "Name": "UserManager",
+        "Claims" : [
+          {
+            "Type": "user",
+            "Value": "read"
+          },
+          {
+            "Type": "user",
+            "Value": "create"
+          },
+          {
+            "Type": "user",
+            "Value": "update"
+          }
+        ]
+      }
+    ],
+    "Users": [
+      {
+        "UserName": "RoleManager",
+        "Email": "rolemanager@example.com",
+        "Name": "RoleManager",
+        "LastName": "RoleManager",
+        "Password": "RoleManager@123",
+        "Roles": [
+          "RoleManager"
+        ]
+      },
+      {
+        "UserName": "UserManager",
+        "Email": "usermanager@example.com",
+        "Name": "UserManager",
+        "LastName": "UserManager",
+        "Password": "UserManager@123",
+        "Roles": [
+          "UserManager"
+        ]
+      }
+    ]
+  },
   "JWT": {
     "Issuer": "AuthServer",
     "Audience": "User",
     "Key": "SuperSecureKey0909!"
   },
-  "DataSeeding": {
-    "Roles": [
-      "CustomRole1",
-      "CustomRole2"
-    ],
-    "Users": [
-      {
-        "UserName": "User1",
-        "Email": "user1@example.com",
-        "Name": "User",
-        "LastName": "One",
-        "Password": "User@123",
-        "Roles": [
-          "CustomRole1"
-        ]
-      },
-      {
-        "UserName": "User2",
-        "Email": "user2@example.com",
-        "Name": "User",
-        "LastName": "Two",
-        "Password": "User@123",
-        "Roles": [
-          "CustomRole2"
-        ]
-      }
-    ]
-  }
+  "APIKeys": [
+    "TestAPIKEY1"
+  ]
 }

--- a/src/Kirel.Identity.Server.API/appsettings.json
+++ b/src/Kirel.Identity.Server.API/appsettings.json
@@ -6,7 +6,7 @@
     }
   },
   "AllowedHosts": "*",
-  "DbConfig": {
+  "dbConfig": {
     "Driver": "sqlite",
     "Params": {
       "Address": "localhost",
@@ -24,28 +24,60 @@
   },
   "DataSeeding": {
     "Roles": [
-      "CustomRole1",
-      "CustomRole2"
-    ],
-    "Users": [
       {
-        "UserName": "User1",
-        "Email": "user1@example.com",
-        "Name": "User",
-        "LastName": "One",
-        "Password": "User@123",
-        "Roles": [
-          "CustomRole1"
+        "Name": "RoleManager",
+        "Claims" : [
+          {
+            "Type": "role_claim",
+            "Value": "read"
+          },
+          {
+            "Type": "role_claim",
+            "Value": "create"
+          },
+          {
+            "Type": "role_claim",
+            "Value": "update"
+          }
         ]
       },
       {
-        "UserName": "User2",
-        "Email": "user2@example.com",
-        "Name": "User",
-        "LastName": "Two",
-        "Password": "User@123",
+        "Name": "UserManager",
+        "Claims" : [
+          {
+            "Type": "user",
+            "Value": "read"
+          },
+          {
+            "Type": "user",
+            "Value": "create"
+          },
+          {
+            "Type": "user",
+            "Value": "update"
+          }
+        ]
+      }
+    ],
+    "Users": [
+      {
+        "UserName": "RoleManager",
+        "Email": "rolemanager@example.com",
+        "Name": "RoleManager",
+        "LastName": "RoleManager",
+        "Password": "RoleManager@123",
         "Roles": [
-          "CustomRole2"
+          "RoleManager"
+        ]
+      },
+      {
+        "UserName": "UserManager",
+        "Email": "usermanager@example.com",
+        "Name": "UserManager",
+        "LastName": "UserManager",
+        "Password": "UserManager@123",
+        "Roles": [
+          "UserManager"
         ]
       }
     ]

--- a/src/Kirel.Identity.Server.Core/Mappers/ClaimMapper.cs
+++ b/src/Kirel.Identity.Server.Core/Mappers/ClaimMapper.cs
@@ -1,5 +1,6 @@
 ﻿using System.Security.Claims;
 using AutoMapper;
+using Kirel.Identity.Server.Domain;
 using Kirel.Identity.Server.DTOs;
 
 namespace Kirel.Identity.Server.Core.Mappers;
@@ -14,8 +15,35 @@ public class ClaimMapper : Profile
     /// </summary>
     public ClaimMapper()
     {
-        CreateMap<Claim, ClaimDto>().ReverseMap();
-        CreateMap<Claim, ClaimCreateDto>().ReverseMap();
-        CreateMap<Claim, ClaimUpdateDto>().ReverseMap();
+        CreateMap<Claim, ClaimDto>()
+            .ForMember(s => s.Type, opt => opt.MapFrom(d => d.Type))
+            .ForMember(s => s.Value, opt => opt.MapFrom(d => d.Value));
+        CreateMap<UserClaim, ClaimDto>()
+            .ForMember(s => s.Type, opt => opt.MapFrom(d => d.ClaimType))
+            .ForMember(s => s.Value, opt => opt.MapFrom(d => d.ClaimValue));
+        CreateMap<RoleClaim, ClaimDto>()
+            .ForMember(s => s.Type, opt => opt.MapFrom(d => d.ClaimType))
+            .ForMember(s => s.Value, opt => opt.MapFrom(d => d.ClaimValue));
+        
+        CreateMap<ClaimCreateDto, Claim>()
+            .ForMember(s => s.Type, opt => opt.MapFrom(d => d.Type))
+            .ForMember(s => s.Value, opt => opt.MapFrom(d => d.Value));
+            
+        CreateMap<ClaimCreateDto, UserClaim>()
+            .ForMember(s => s.ClaimType, opt => opt.MapFrom(d => d.Type))
+            .ForMember(s => s.ClaimValue, opt => opt.MapFrom(d => d.Value));
+        CreateMap<ClaimCreateDto, RoleClaim>()
+            .ForMember(s => s.ClaimType, opt => opt.MapFrom(d => d.Type))
+            .ForMember(s => s.ClaimValue, opt => opt.MapFrom(d => d.Value));
+
+        CreateMap<ClaimUpdateDto, Claim>()
+            .ForMember(s => s.Type, opt => opt.MapFrom(d => d.Type))
+            .ForMember(s => s.Value, opt => opt.MapFrom(d => d.Value));
+        CreateMap<ClaimUpdateDto, UserClaim>()
+            .ForMember(s => s.ClaimType, opt => opt.MapFrom(d => d.Type))
+            .ForMember(s => s.ClaimValue, opt => opt.MapFrom(d => d.Value));
+        CreateMap<ClaimUpdateDto, RoleClaim>()
+            .ForMember(s => s.ClaimType, opt => opt.MapFrom(d => d.Type))
+            .ForMember(s => s.ClaimValue, opt => opt.MapFrom(d => d.Value));
     }
 }

--- a/src/Kirel.Identity.Server.Core/Mappers/RoleMapper.cs
+++ b/src/Kirel.Identity.Server.Core/Mappers/RoleMapper.cs
@@ -14,8 +14,8 @@ public class RoleMapper : Profile
     /// </summary>
     public RoleMapper()
     {
-        CreateMap<Role, RoleDto>().ReverseMap();
-        CreateMap<Role, RoleCreateDto>().ReverseMap();
-        CreateMap<Role, RoleUpdateDto>().ReverseMap();
+        CreateMap<Role, RoleDto>();
+        CreateMap<RoleCreateDto, Role>();
+        CreateMap<RoleUpdateDto, Role>();
     }
 }

--- a/src/Kirel.Identity.Server.Core/Mappers/UserMapper.cs
+++ b/src/Kirel.Identity.Server.Core/Mappers/UserMapper.cs
@@ -14,11 +14,17 @@ public class UserMapper : Profile
     /// </summary>
     public UserMapper()
     {
-        CreateMap<User, UserDto>().ReverseMap();
-        CreateMap<User, UserCreateDto>().ReverseMap();
-        CreateMap<User, UserUpdateDto>().ReverseMap();
-        CreateMap<User, UserRegistrationDto>().ReverseMap();
-        CreateMap<User, AuthorizedUserDto>().ReverseMap();
-        CreateMap<User, AuthorizedUserUpdateDto>().ReverseMap();
+        CreateMap<User, UserDto>()
+            .ForMember(d => d.Roles, 
+            opt => opt.MapFrom(s => s.UserRoles.Select(ur => ur.RoleId)));
+        CreateMap<User, AuthorizedUserDto>();
+        CreateMap<UserCreateDto, User>().ForMember(d => d.UserRoles, opt => opt.MapFrom(
+            s => s.Roles.Select(r => new UserRole() {RoleId = r})
+        ));
+        CreateMap<UserUpdateDto, User>().ForMember(d => d.UserRoles, 
+        opt => opt.MapFrom(source => source.Roles.Select(id => new UserRole(){RoleId = id}).ToList())
+        );
+        CreateMap<UserRegistrationDto, User>();
+        CreateMap<AuthorizedUserUpdateDto, User>();
     }
 }

--- a/src/Kirel.Identity.Server.Core/Services/AuthenticationService.cs
+++ b/src/Kirel.Identity.Server.Core/Services/AuthenticationService.cs
@@ -5,7 +5,7 @@ using Microsoft.AspNetCore.Identity;
 namespace Kirel.Identity.Server.Core.Services;
 
 /// <inheritdoc />
-public class AuthenticationService : KirelAuthenticationService<Guid, User, Role, UserRole>
+public class AuthenticationService : KirelAuthenticationService<Guid, User, Role, UserRole, UserClaim, RoleClaim>
 {
     /// <inheritdoc />
     public AuthenticationService(UserManager<User> userManager) : base(userManager)

--- a/src/Kirel.Identity.Server.Core/Services/AuthorizedUserService.cs
+++ b/src/Kirel.Identity.Server.Core/Services/AuthorizedUserService.cs
@@ -8,7 +8,7 @@ using Microsoft.AspNetCore.Identity;
 namespace Kirel.Identity.Server.Core.Services;
 
 /// <inheritdoc />
-public class AuthorizedUserService : KirelAuthorizedUserService<Guid, User, Role, UserRole, AuthorizedUserDto, AuthorizedUserUpdateDto>
+public class AuthorizedUserService : KirelAuthorizedUserService<Guid, User, Role, UserRole, UserClaim, RoleClaim, AuthorizedUserDto, AuthorizedUserUpdateDto>
 {
     /// <inheritdoc />
     public AuthorizedUserService(IHttpContextAccessor httpContextAccessor, UserManager<User> userManager,

--- a/src/Kirel.Identity.Server.Core/Services/JwtTokenService.cs
+++ b/src/Kirel.Identity.Server.Core/Services/JwtTokenService.cs
@@ -6,11 +6,11 @@ using Microsoft.AspNetCore.Identity;
 namespace Kirel.Identity.Server.Core.Services;
 
 /// <inheritdoc />
-public class JwtTokenService : KirelJwtTokenService<Guid, User, Role, UserRole>
+public class JwtTokenService : KirelJwtTokenService<Guid, User, Role, UserRole, UserClaim, RoleClaim>
 {
     /// <inheritdoc />
-    public JwtTokenService(UserManager<User> userManager, RoleManager<Role> roleManager, KirelAuthOptions authOptions) :
-        base(userManager, roleManager, authOptions)
+    public JwtTokenService(KirelAuthOptions authOptions) :
+        base(authOptions)
     {
     }
 }

--- a/src/Kirel.Identity.Server.Core/Services/RegistrationService.cs
+++ b/src/Kirel.Identity.Server.Core/Services/RegistrationService.cs
@@ -7,7 +7,7 @@ using Microsoft.AspNetCore.Identity;
 namespace Kirel.Identity.Server.Core.Services;
 
 /// <inheritdoc />
-public class RegistrationService : KirelRegistrationService<Guid, User, Role, UserRole, UserRegistrationDto>
+public class RegistrationService : KirelRegistrationService<Guid, User, Role, UserRole, UserClaim, RoleClaim, UserRegistrationDto>
 {
     /// <inheritdoc />
     public RegistrationService(UserManager<User> userManager, IMapper mapper) : base(userManager, mapper)

--- a/src/Kirel.Identity.Server.Core/Services/RoleService.cs
+++ b/src/Kirel.Identity.Server.Core/Services/RoleService.cs
@@ -7,7 +7,7 @@ using Microsoft.AspNetCore.Identity;
 namespace Kirel.Identity.Server.Core.Services;
 
 /// <inheritdoc />
-public class RoleService : KirelRoleService<Guid, Role, User, UserRole, RoleDto, RoleCreateDto, RoleUpdateDto, ClaimDto, ClaimCreateDto,
+public class RoleService : KirelRoleService<Guid, Role, User, UserRole, RoleClaim, UserClaim, RoleDto, RoleCreateDto, RoleUpdateDto, ClaimDto, ClaimCreateDto,
     ClaimUpdateDto>
 {
     /// <inheritdoc />

--- a/src/Kirel.Identity.Server.Core/Services/UserService.cs
+++ b/src/Kirel.Identity.Server.Core/Services/UserService.cs
@@ -7,12 +7,11 @@ using Microsoft.AspNetCore.Identity;
 namespace Kirel.Identity.Server.Core.Services;
 
 /// <inheritdoc />
-public class UserService : KirelUserService<Guid, User, Role, UserRole, UserDto, UserCreateDto, UserUpdateDto, ClaimDto,
+public class UserService : KirelUserService<Guid, User, Role, UserRole, UserClaim, RoleClaim, UserDto, UserCreateDto, UserUpdateDto, ClaimDto,
     ClaimCreateDto, ClaimUpdateDto>
 {
     /// <inheritdoc />
-    public UserService(UserManager<User> userManager, RoleManager<Role> roleManager, IMapper mapper) : base(userManager,
-        roleManager, mapper)
+    public UserService(UserManager<User> userManager, RoleManager<Role> roleManager, IMapper mapper) : base(userManager, mapper)
     {
     }
 }

--- a/src/Kirel.Identity.Server.Core/Validators/RoleCreateDtoValidator.cs
+++ b/src/Kirel.Identity.Server.Core/Validators/RoleCreateDtoValidator.cs
@@ -6,7 +6,7 @@ using Microsoft.AspNetCore.Identity;
 namespace Kirel.Identity.Server.Core.Validators;
 
 /// <inheritdoc />
-public class RoleCreateDtoValidator : KirelRoleCreateDtoValidator<Guid, Role, User, UserRole, RoleCreateDto, ClaimCreateDto>
+public class RoleCreateDtoValidator : KirelRoleCreateDtoValidator<Guid, Role, User, UserRole, RoleClaim, UserClaim, RoleCreateDto, ClaimCreateDto>
 {
     /// <inheritdoc />
     public RoleCreateDtoValidator(RoleManager<Role> roleManager) : base(roleManager)

--- a/src/Kirel.Identity.Server.Core/Validators/RoleUpdateDtoValidator.cs
+++ b/src/Kirel.Identity.Server.Core/Validators/RoleUpdateDtoValidator.cs
@@ -7,7 +7,7 @@ using Microsoft.AspNetCore.Identity;
 namespace Kirel.Identity.Server.Core.Validators;
 
 /// <inheritdoc />
-public class RoleUpdateDtoValidator : KirelRoleUpdateDtoValidator<Guid, Role, User, UserRole, RoleUpdateDto, ClaimUpdateDto>
+public class RoleUpdateDtoValidator : KirelRoleUpdateDtoValidator<Guid, Role, User, UserRole, RoleClaim, UserClaim, RoleUpdateDto, ClaimUpdateDto>
 {
     /// <inheritdoc />
     public RoleUpdateDtoValidator(RoleManager<Role> roleManager, IHttpContextAccessor httpContextAccessor) : base(

--- a/src/Kirel.Identity.Server.Core/Validators/UserCreateDtoValidator.cs
+++ b/src/Kirel.Identity.Server.Core/Validators/UserCreateDtoValidator.cs
@@ -7,7 +7,7 @@ using Microsoft.Extensions.Options;
 namespace Kirel.Identity.Server.Core.Validators;
 
 /// <inheritdoc />
-public class UserCreateDtoValidator : KirelUserCreateDtoValidator<Guid, User, Role, UserRole, UserCreateDto, ClaimCreateDto>
+public class UserCreateDtoValidator : KirelUserCreateDtoValidator<Guid, User, Role, UserRole, UserClaim, RoleClaim, UserCreateDto, ClaimCreateDto>
 {
     /// <inheritdoc />
     public UserCreateDtoValidator(IOptions<IdentityOptions> identityOptions, UserManager<User> userManager,

--- a/src/Kirel.Identity.Server.Core/Validators/UserUpdateDtoValidator.cs
+++ b/src/Kirel.Identity.Server.Core/Validators/UserUpdateDtoValidator.cs
@@ -8,7 +8,7 @@ using Microsoft.Extensions.Options;
 namespace Kirel.Identity.Server.Core.Validators;
 
 /// <inheritdoc />
-public class UserUpdateDtoValidator : KirelUserUpdateDtoValidator<Guid, User, Role, UserRole, UserUpdateDto, ClaimUpdateDto>
+public class UserUpdateDtoValidator : KirelUserUpdateDtoValidator<Guid, User, Role, UserRole, UserClaim, RoleClaim, UserUpdateDto, ClaimUpdateDto>
 {
     /// <inheritdoc />
     public UserUpdateDtoValidator(IOptions<IdentityOptions> identityOptions, UserManager<User> userManager,

--- a/src/Kirel.Identity.Server.Domain/Role.cs
+++ b/src/Kirel.Identity.Server.Domain/Role.cs
@@ -3,6 +3,6 @@
 namespace Kirel.Identity.Server.Domain;
 
 /// <inheritdoc />
-public class Role : KirelIdentityRole<Guid, Role, User, UserRole>
+public class Role : KirelIdentityRole<Guid, Role, User, UserRole, RoleClaim, UserClaim>
 {
 }

--- a/src/Kirel.Identity.Server.Domain/User.cs
+++ b/src/Kirel.Identity.Server.Domain/User.cs
@@ -3,6 +3,6 @@
 namespace Kirel.Identity.Server.Domain;
 
 /// <inheritdoc />
-public class User : KirelIdentityUser<Guid, User, Role, UserRole>
+public class User : KirelIdentityUser<Guid, User, Role, UserRole, UserClaim, RoleClaim>
 {
 }

--- a/src/Kirel.Identity.Server.Domain/UserRole.cs
+++ b/src/Kirel.Identity.Server.Domain/UserRole.cs
@@ -3,6 +3,6 @@
 namespace Kirel.Identity.Server.Domain;
 
 /// <inheritdoc />
-public class UserRole : KirelIdentityUserRole<Guid, UserRole, User, Role>
+public class UserRole : KirelIdentityUserRole<Guid, UserRole, User, Role, UserClaim, RoleClaim>
 {
 }


### PR DESCRIPTION
In my projects we want to use claims based authozrization, so we are completely switching to them. Claim model is a CRUD based.

- Now we use our internal DTO for paged output.
- Now we use our internal predicate builder for build predicate search in all fields.
- Now we have navigation from user to claims and from roles to claims in base models.